### PR TITLE
Fixes bug in errCalculateCentroid (Polygon.h)

### DIFF
--- a/src/cpp/Plans/Polygon.h
+++ b/src/cpp/Plans/Polygon.h
@@ -469,7 +469,7 @@ public:    //methods/functions
                 for(auto itVertex=m_viVerticies.begin();itVertex!=m_viVerticies.end();itVertex++)
                 {
                     dTotalNorth += vposVertexContainer[*itVertex].m_north_m;
-                    dTotalEast += vposVertexContainer[*itVertex].m_north_m;
+                    dTotalEast += vposVertexContainer[*itVertex].m_east_m;
                 }
                 assert(!viGetVerticies().empty());
                 posGetCentroid().m_north_m = dTotalNorth/viGetVerticies().size();


### PR DESCRIPTION
Fixes errCalculateCentroid to use East instead of North when summing the total contributions from the East.