### PR TITLE
Update uxas tox for mypy and bandit

### DIFF
--- a/infrastructure/uxas/tox.ini
+++ b/infrastructure/uxas/tox.ini
@@ -8,6 +8,7 @@ basepython = python3
 deps =
     black
     mypy
+    types-PyYAML
     flake8
     flake8-bugbear
     flake8-builtins
@@ -26,7 +27,8 @@ deps =
     bandit
     safety
 commands =
-    bandit -r uxas
+    # skipped tests relate to the use of subprocess in devel_setup
+    bandit -r src -s B404,B603,B607
     safety check --full-report
 
 [pytest]


### PR DESCRIPTION
This commit solves two problems:

1. newer mypys want to have typedefs in place for YAML. This is solved
   by installing the recommended (by mypy) package.

2. bandit was misconfigured so that it wasn't actually checking
   anything. This was solved by specifying the src directory for bandit
   to check. This results in some info messages about the use of the
   `subprocess` module, which is not recommended, but which is okay for
   our purposes. These tests have been disabled so the messages aren't
   emitted.