### PR TITLE
Fix errors for RunLmcpGen.py (#30)

### DIFF
--- a/infrastructure/uxas/src/uxas/paths.py
+++ b/infrastructure/uxas/src/uxas/paths.py
@@ -9,17 +9,10 @@ import os
 # aren't set. I'm not sure how I feel about that.
 __ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 
-FALLBACK_REPO_DIR = os.path.realpath(
-    os.path.join(
-        __ROOT_DIR,
-        "..",
-        "..",
-        "..",
-        "..",
-        "..",
-        "..",
-    )
-)
+# Fall back by splitting our path on .vpython and taking the front part. This
+# should dump us at the root of the OpenUxAS repo and is hopefully more robust
+# than walking a relative path a fixed number of steps.
+FALLBACK_REPO_DIR = os.path.realpath(__ROOT_DIR.split(".vpython")[0])
 
 # Now we read the environment and fall back on rebuilding the paths manually.
 OPENUXAS_ROOT = os.environ.get("OPENUXAS_ROOT", FALLBACK_REPO_DIR)

--- a/resources/RunLmcpGen.py
+++ b/resources/RunLmcpGen.py
@@ -137,8 +137,9 @@ def compute_env() -> _Environ:
             ).strip(),
         )
 
-        for i in range(0, len(a), 2):
-            base_env[a[i]] = a[i + 1]
+        if len(a) % 2 == 0:
+            for i in range(0, len(a), 2):
+                base_env[a[i]] = a[i + 1]
 
     return base_env
 


### PR DESCRIPTION
RunLmcpGen.py no longer worked; the paths returned by the `uxas.paths`
python module were not correct; they were relative to the parent
directory of the OpenUxAS repo, not to the OpenUxAS repo itself.

Most likely, this occurred because of some change in the way the module
was installed in the python venv. To make this more robust, the paths
are now computed different: they look explicitly for the parent of the
.vpython directory itself.

Additionally, there was a possibility that the computation of the
`base_env` in RunLmcpGen.py would fail: the loop indexing requires that
the length of the array mod 2 be zero. This is now encoded explicitly.