### PR TITLE
Improve run_example.py

### DIFF
--- a/.github/workflows/run-example.yml
+++ b/.github/workflows/run-example.yml
@@ -1,0 +1,66 @@
+on:
+    push:
+        paths:
+            - 'infrastructure/uxas/**'
+            - 'infrastructure/paths.sh'
+            - 'infrastructure/specs/**'
+            - 'infrastructure/run_example.py'
+            - 'anod'
+            - 'src/cpp/**'
+            - 'run-example'
+    pull_request:
+        paths:
+            - 'infrastructure/uxas/**'
+            - 'infrastructure/paths.sh'
+            - 'infrastructure/specs/**'
+            - 'infrastructure/run_example.py'
+            - 'anod'
+            - 'src/cpp/**'
+            - 'run-example'
+    workflow_dispatch:
+    schedule:
+        - cron: '20 3 * * 4'
+
+name: Test run-example
+jobs:
+    build:
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-18.04, ubuntu-20.04]
+                python-version: [3.7, 3.8]
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  path: OpenUxAS
+
+            - name: Set up python ${{ matrix.python-version }}
+              uses: actions/setup-python@v2
+              with:
+                  python-version: ${{ matrix.python-version }}
+
+            - name: Set up java
+              uses: actions/setup-java@v1
+              with:
+                  java-version: '11'
+
+            - name: Install infrastructure
+              run: |
+                  cd OpenUxAS
+                  infrastructure/install -vv --no-gnat --no-java -y
+
+            - name: Build OpenUxAS C++
+              run: |
+                  cd OpenUxAS
+                  ./anod -v build uxas
+
+            - name: Build OpenAMASE
+              run: |
+                  cd OpenUxAS
+                  ./anod -v build amase
+
+            - name: Test run-example
+              run: |
+                  cd OpenUxAS
+                  ./run-example 01_HelloWorld

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ __pycache__
 .mypy_cache
 .coverage
 .tox
+*.egg-info
+.flake8
 
 # Ignore build directories
 /prerequisites/sbx

--- a/infrastructure/run_example.py
+++ b/infrastructure/run_example.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python3
-
 """Script to run OpenUxAS examples."""
 
 from __future__ import annotations
@@ -10,6 +8,7 @@ import os
 import pathlib
 import shutil
 import subprocess
+import sys
 import time
 import traceback
 from typing import TYPE_CHECKING
@@ -97,7 +96,7 @@ RUN_DIR = "RUNDIR"
 
 def read_yaml(yaml_filename: str) -> Dict[str, Any]:
     """Read and parse a YAML file, returning the content as a yaml object."""
-    with open(yaml_filename) as yaml_file:
+    with open(yaml_filename, encoding="utf-8") as yaml_file:
         loaded_yaml = yaml.safe_load(yaml_file.read())
 
     return loaded_yaml
@@ -115,29 +114,29 @@ MISSING_AMASE = """\
 Before you can run examples that use OpenAMASE, you need to build it. You
 should:
 
-    {anod} build amase
+    %s build amase
 """
 
 UNBUILT_SPECIFIED_AMASE = """\
-The OpenAMASE path `{path}` exists, but hasn't been built. You should:
+The OpenAMASE path `%s exists, but hasn't been built. You should:
 
-    cd "{path}/OpenAMASE" && ant
+    cd "%s/OpenAMASE" && ant
 
 You may need to put ant on your path first, like this:
 
-    eval "$( {anod} printenv ant )"
+    eval "$( %s printenv ant )"
 """
 
 
 UNBUILT_LOCAL_AMASE = """\
-There is an OpenAMASE in {path}, but it hasn't been built. If you
+There is an OpenAMASE in %s, but it hasn't been built. If you
 want to use this version of OpenAMASE, you should:
 
-    cd "{path}/OpenAMASE" && ant
+    cd "%s/OpenAMASE" && ant
 
 You may need to put ant on your path first, like this:
 
-    eval "$( {anod} printenv ant )"
+    eval "$( %s printenv ant )"
 
 Trying the anod-built OpenAMASE as a fall back.
 """
@@ -165,22 +164,22 @@ def resolve_amase_dir(args: Namespace) -> str:
             return args.amase_dir
         else:
             logging.critical(
-                UNBUILT_SPECIFIED_AMASE.format(path=args.amase_dir, anod=ANOD_CMD)
+                UNBUILT_SPECIFIED_AMASE, args.amase_dir, args.amase_dir, ANOD_CMD
             )
-            exit(1)
+            sys.exit(1)
 
     if os.path.exists(AMASE_DIR):
         if check_amase_dir(AMASE_DIR):
             return AMASE_DIR
         else:
-            logging.warning(UNBUILT_LOCAL_AMASE.format(path=AMASE_DIR, anod=ANOD_CMD))
+            logging.warning(UNBUILT_LOCAL_AMASE, AMASE_DIR, AMASE_DIR, ANOD_CMD)
 
     anod_amase_dir = os.path.join(SBX_DIR, "x86_64-linux", "amase", "src")
     if os.path.exists(anod_amase_dir) and check_amase_dir(anod_amase_dir):
         return anod_amase_dir
     else:
-        logging.critical(MISSING_AMASE.format(anod=ANOD_CMD))
-        exit(1)
+        logging.critical(MISSING_AMASE, ANOD_CMD)
+        sys.exit(1)
 
 
 def list_examples(examples_dir: str) -> None:
@@ -210,12 +209,12 @@ def check_amase(
 
     if SCENARIO_YAML_KEY not in loaded_yaml[AMASE_YAML_KEY].keys():
         logging.critical("OpenAMASE configuration must specify a scenario file.")
-        exit(1)
+        sys.exit(1)
 
     scenario_file = loaded_yaml[AMASE_YAML_KEY][SCENARIO_YAML_KEY]
     if not os.path.exists(os.path.join(example_dir, scenario_file)):
-        logging.critical(f"Specified scenario file '{scenario_file}' does not exist.")
-        exit(1)
+        logging.critical("Specified scenario file '%s' does not exist.", scenario_file)
+        sys.exit(1)
 
     if args.amase_delay is not None:
         amase_delay = args.amase_delay
@@ -232,9 +231,9 @@ def run_amase(scenario_file: str, example_dir: str, amase_dir: str) -> subproces
     amase_cmd = [
         "java",
         "-Xmx2048m",
-        "-splash:%s" % os.path.join("data", "amase_splash.png"),
+        f"-splash:{os.path.join('data', 'amase_splash.png')}",
         "-classpath",
-        "%s:%s" % (os.path.join("dist", "*"), os.path.join("lib", "*")),
+        f"{os.path.join('dist', '*')}:{os.path.join('lib', '*')}",
         "avtas.app.Application",
         "--config",
         os.path.join("config", "amase"),
@@ -243,18 +242,20 @@ def run_amase(scenario_file: str, example_dir: str, amase_dir: str) -> subproces
     ]
 
     logging.info(
-        "Running OpenAMASE in\n"
-        f"             {amase_dir}\n"
-        f"         with scenario '{scenario_file}'."
+        "Running OpenAMASE in\n             %s\n" "         with scenario '%s'.",
+        amase_dir,
+        scenario_file,
     )
     logging.debug(
-        f"Run: cd {os.path.join(amase_dir, 'OpenAMASE')}; {' '.join(amase_cmd)}"
+        "Run: cd %s; %s",
+        os.path.join(amase_dir, "OpenAMASE"),
+        " ".join(amase_cmd),
     )
 
     return subprocess.Popen(amase_cmd, cwd=os.path.join(amase_dir, "OpenAMASE"))
 
 
-def check_uxas(loaded_yaml: Dict[str, Any], args: Namespace) -> List[Dict[str, str]]:
+def check_uxas(loaded_yaml: Dict[str, Any], example_dir: str) -> List[Dict[str, str]]:
     """
     Check the OpenUxAS configuration in the YAML and return a list of configs.
 
@@ -264,9 +265,9 @@ def check_uxas(loaded_yaml: Dict[str, Any], args: Namespace) -> List[Dict[str, s
 
     if UXASES_YAML_KEY in loaded_yaml.keys():
         for record in loaded_yaml[UXASES_YAML_KEY]:
-            uxas_configs += [check_one_uxas(record, args)]
+            uxas_configs += [check_one_uxas(record, example_dir)]
     elif UXAS_YAML_KEY in loaded_yaml.keys():
-        uxas_configs += [check_one_uxas(loaded_yaml[UXAS_YAML_KEY], args)]
+        uxas_configs += [check_one_uxas(loaded_yaml[UXAS_YAML_KEY], example_dir)]
 
     return uxas_configs
 
@@ -308,17 +309,17 @@ def find_uxas_bin(bin_name: str) -> Optional[str]:
 
 
 MISSING_BIN = """\
-The command `{bin}` cannot be found on your path. Either specify the absolute
+The command `%s` cannot be found on your path. Either specify the absolute
 path to the desired OpenUXAS binary in the config file (*not recommended*),
 manually add the desired OpenUxAS binary to your path, perfom a local build of
 the binary (e.g., for C++, `make -j all`) or use anod to build the desired
 version of OpenUxAS with, e.g., for C++:
 
-    {anod} build {bin}
+    %s build %s
 """
 
 
-def check_one_uxas(record: Dict[str, str], args: Namespace) -> Dict[str, str]:
+def check_one_uxas(record: Dict[str, str], example_dir: str) -> Dict[str, str]:
     """
     Check one OpenUxAS configuration from the YAML and return the config.
 
@@ -326,12 +327,12 @@ def check_one_uxas(record: Dict[str, str], args: Namespace) -> Dict[str, str]:
     """
     if CONFIG_YAML_KEY not in record.keys():
         logging.critical("OpenUxAS configuration must specify a config file.")
-        exit(1)
+        sys.exit(1)
 
     config_file = record[CONFIG_YAML_KEY]
     if not os.path.exists(os.path.join(example_dir, config_file)):
-        logging.critical(f"Specified config file '{config_file}' does not exist.")
-        exit(1)
+        logging.critical("Specified config file '%s' does not exist.", config_file)
+        sys.exit(1)
 
     run_dir_name = RUN_DIR
     if RUNDIR_YAML_KEY in record.keys():
@@ -344,8 +345,8 @@ def check_one_uxas(record: Dict[str, str], args: Namespace) -> Dict[str, str]:
 
     uxas_binary = find_uxas_bin(bin_name)
     if uxas_binary is None:
-        logging.critical(MISSING_BIN.format(bin=bin_name, anod=ANOD_CMD))
-        exit(1)
+        logging.critical(MISSING_BIN, bin_name, ANOD_CMD, bin_name)
+        sys.exit(1)
 
     return {
         "config_file": config_file,
@@ -358,7 +359,7 @@ def run_uxas(
     uxas_configs: List[Dict[str, str]], example_dir: str, popen: bool
 ) -> List[subprocess.Popen]:
     """Run an OpenUxAS instance for each configuration."""
-    pids = list()
+    pids = []
     for config in uxas_configs:
         pid = run_one_uxas(config, example_dir, popen)
         if pid is not None:
@@ -367,7 +368,7 @@ def run_uxas(
     if popen:
         return pids
     else:
-        return list()
+        return []
 
 
 def run_one_uxas(
@@ -386,27 +387,33 @@ def run_one_uxas(
     if popen:
         logging.info(
             "Running OpenUxAS binary\n"
-            f"             {uxas_bin}\n"
+            "             %s\n"
             "         in a separate process with configuration\n"
-            f"             {config_file}\n"
+            "             %s\n"
             "         Data and logfiles are in:\n"
-            f"             {run_dir}"
+            "             %s",
+            uxas_bin,
+            config_file,
+            run_dir,
         )
-        logging.debug(f"Run: cd {run_dir}; {' '.join(uxas_cmd)}")
+        logging.debug("Run: cd %s; %s", run_dir, " ".join(uxas_cmd))
 
         return subprocess.Popen(uxas_cmd, cwd=run_dir)
     else:
         logging.info(
             "Running OpenUxAS binary\n"
-            f"             {uxas_bin}\n"
+            "             %s\n"
             "         with configuration\n"
-            f"             {config_file}\n"
+            "             %s\n"
             "         Data and logfiles are in:\n"
-            f"             {run_dir}"
+            "             %s",
+            uxas_bin,
+            config_file,
+            run_dir,
         )
-        logging.debug(f"Run: cd {run_dir}; {' '.join(uxas_cmd)}")
+        logging.debug("Run: cd %s; %s", run_dir, " ".join(uxas_cmd))
 
-        subprocess.run(uxas_cmd, cwd=run_dir)
+        subprocess.run(uxas_cmd, cwd=run_dir, check=True)
         return None
 
 
@@ -428,7 +435,7 @@ def killall_uxases(popen: bool, pids: List[subprocess.Popen]) -> None:
                 # the process was actually killed, so we wait a moment.
                 time.sleep(0.1)
                 if pid.poll() is None:
-                    logging.error(f"  Unable to kill PID {pid.pid}.")
+                    logging.error("  Unable to kill PID %s.", pid.pid)
 
 
 # From
@@ -439,9 +446,9 @@ class _ListAction(argparse.Action):
         option_strings,
         dest=argparse.SUPPRESS,
         default=argparse.SUPPRESS,
-        help=None,
+        help=None,  # (needed for superclass) pylint: disable=redefined-builtin
     ):
-        super(_ListAction, self).__init__(
+        super().__init__(
             option_strings=option_strings,
             dest=dest,
             default=default,
@@ -467,9 +474,9 @@ class _CompleteOptionsAction(argparse.Action):
         option_strings,
         dest=argparse.SUPPRESS,
         default=argparse.SUPPRESS,
-        help=None,
+        help=None,  # (needed for superclass) pylint: disable=redefined-builtin
     ):
-        super(_CompleteOptionsAction, self).__init__(
+        super().__init__(
             option_strings=option_strings,
             dest=dest,
             default=default,
@@ -485,14 +492,14 @@ class _CompleteOptionsAction(argparse.Action):
         parser.exit()
 
 
-# Script processing.
-if __name__ == "__main__":
-    ap = argparse.ArgumentParser(
+def run_example_main() -> int:
+    """Run main processing of run-example."""
+    argument_parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description=DESCRIPTION,
     )
 
-    ap.add_argument(
+    argument_parser.add_argument(
         "--delay",
         dest="amase_delay",
         type=int,
@@ -500,22 +507,28 @@ if __name__ == "__main__":
         "before starting instances of OpenUxAS",
     )
 
-    ap.add_argument(
+    argument_parser.add_argument(
         "--amase-dir",
         help="absolute path to the OpenAMASE repository containing build outputs",
     )
 
-    ap.add_argument("--uxas-bin", help="absolute path to the OpenUxAS binary")
+    argument_parser.add_argument(
+        "--uxas-bin",
+        help="absolute path to the OpenUxAS binary",
+    )
 
-    ap.add_argument(
+    argument_parser.add_argument(
         "--uxas-dir",
         default=OPENUXAS_ROOT,
         help="absolute path to the OpenUxAS repository containing build outputs",
     )
 
-    ap.add_argument("--examples-dir", help="absolute path to the root of the examples")
+    argument_parser.add_argument(
+        "--examples-dir",
+        help="absolute path to the root of the examples",
+    )
 
-    ap.add_argument(
+    argument_parser.add_argument(
         "-l",
         "--list",
         dest="list_examples",
@@ -526,21 +539,21 @@ if __name__ == "__main__":
     )
 
     # This is only for driving autocomplete
-    ap.add_argument(
+    argument_parser.add_argument(
         "--complete-options",
         default=False,
         action=_CompleteOptionsAction,
         help=argparse.SUPPRESS,
     )
 
-    ap.add_argument(
+    argument_parser.add_argument(
         "example",
         help="the example directory",
     )
 
-    add_logging_group(ap)
+    add_logging_group(argument_parser)
 
-    args = ap.parse_args()
+    args = argument_parser.parse_args()
 
     activate_logger(args, get_logging_level(args))
 
@@ -559,34 +572,37 @@ if __name__ == "__main__":
         else:
             example_dir = os.path.join(EXAMPLES_DIR, args.example)
 
-        logging.info("Running example in\n" f"           {example_dir}")
+        logging.info("Running example in\n           %s", example_dir)
 
         if not os.path.exists(example_dir):
             example_dir = os.path.join(examples_dir, args.example)
 
             if not os.path.exists(example_dir):
                 logging.critical(
-                    f"Example '{args.example}' does not exist in\n"
-                    f"           {examples_dir}\n"
-                    "        Use the `--list` option for a list of available examples."
+                    "Example '%s' does not exist in\n           %s\n"
+                    "        Use the `--list` option for a list of available examples.",
+                    args.example,
+                    examples_dir,
                 )
-                exit(1)
+                return 1
 
         yaml_filename = os.path.join(example_dir, CONFIG_FILE)
         if not os.path.exists(yaml_filename):
             logging.critical(
-                f"Example '{args.example}' is not property configured.\n"
-                f"        There is no '{CONFIG_FILE}' in the example directory.\n"
-                "        Use the `--list` option for a list of available examples."
+                "Example '%s' is not property configured.\n"
+                "        There is no '%s' in the example directory.\n"
+                "        Use the `--list` option for a list of available examples.",
+                args.example,
+                CONFIG_FILE,
             )
-            exit(1)
+            return 1
 
         loaded_yaml = read_yaml(yaml_filename)
 
         amase_dir = resolve_amase_dir(args)
         (scenario_file, amase_delay) = check_amase(loaded_yaml, example_dir, args)
 
-        uxas_configs = check_uxas(loaded_yaml, args)
+        uxas_configs = check_uxas(loaded_yaml, example_dir)
 
         if scenario_file:
             amase_pid = run_amase(scenario_file, example_dir, amase_dir)
@@ -606,12 +622,20 @@ if __name__ == "__main__":
             amase_pid.wait()
 
         killall_uxases(popen, pids)
+        return 0
 
     except KeyboardInterrupt:
         print(" ")
         killall_uxases(popen, pids)
+        return 2
 
-    except Exception as e:
-        logging.critical(f"Got an exception {e}")
+    except Exception as exception:  # pylint: disable=broad-except
+        logging.critical("Got an exception %s", exception)
         traceback.print_exc()
-        ap.print_usage()
+        argument_parser.print_usage()
+        return 3
+
+
+# Script processing.
+if __name__ == "__main__":
+    sys.exit(run_example_main())

--- a/run-example
+++ b/run-example
@@ -12,7 +12,7 @@ source "${SCRIPT_DIR}/infrastructure/paths.sh"
 activate_venv
 
 # Just in case, for uxas-ada. A bit ugly and special-purpose. Use build-env to
-# avoid directly putting uxas-ada itself on the path (in case there's a local 
+# avoid directly putting uxas-ada itself on the path (in case there's a local
 # build)
 debug_and_run "eval \"\$( \"${OPENUXAS_ROOT}/anod\" printenv uxas-ada --build-env )\""
-debug_and_run "python3 \"${INFRASTRUCTURE_DIR}/run-example.py\" $*"
+debug_and_run "python3 \"${INFRASTRUCTURE_DIR}/run_example.py\" $*"


### PR DESCRIPTION
Recent updates to linters revealed a number of potential code-quality
issues.

Most were related to the use of f-strings in loggers, which is
discouraged because the string interpolation is greedy (happens even if
that logging level is disabled) and because it makes the job of log
aggregators more difficult (unlikely to matter to us).

There was an instance of use of a "global" that was not intended to be
such. This was spotted by moving the core script-like functionality into
a function, which avoided adding names to the global namespace.

The script is also renamed to conform to python module-naming
conventions.

All warnings and errors are resolved, except the overly broad catching
of Exception, which is explicitly silenced.

Add a workflow for running the HelloWorld example in CI as a simple
sanity check on run-example functionality.