### PR TITLE
Update infrastructure and run_lmcgen

### DIFF
--- a/infrastructure/paths.sh
+++ b/infrastructure/paths.sh
@@ -12,37 +12,40 @@ else
     export OPENUXAS_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/.. >/dev/null 2>&1 && pwd )"
 fi
 
-export ANOD_BIN="${OPENUXAS_ROOT}/anod"
+: "${ANOD_BIN:=${OPENUXAS_ROOT}/anod}"
 
-export DOC_DIR="${OPENUXAS_ROOT}/doc"
-export EXAMPLES_DIR="${OPENUXAS_ROOT}/examples"
-export INFRASTRUCTURE_DIR="${OPENUXAS_ROOT}/infrastructure"
-export MDMS_DIR="${OPENUXAS_ROOT}/mdms"
-export OBJ_DIR="${OPENUXAS_ROOT}/obj"
-export RESOURCES_DIR="${OPENUXAS_ROOT}/resources"
-export SRC_DIR="${OPENUXAS_ROOT}/src"
-export TESTS_DIR="${OPENUXAS_ROOT}/tests"
+: "${DOC_DIR:=${OPENUXAS_ROOT}/doc}"
+: "${EXAMPLES_DIR:=${OPENUXAS_ROOT}/examples}"
+: "${INFRASTRUCTURE_DIR:=${OPENUXAS_ROOT}/infrastructure}"
+: "${MDMS_DIR:=${OPENUXAS_ROOT}/mdms}"
+: "${OBJ_DIR:=${OPENUXAS_ROOT}/obj}"
+: "${RESOURCES_DIR:=${OPENUXAS_ROOT}/resources}"
+: "${SRC_DIR:=${OPENUXAS_ROOT}/src}"
+: "${TESTS_DIR:=${OPENUXAS_ROOT}/tests}"
 
-export CPP_DIR="${SRC_DIR}/cpp"
-export ADA_DIR="${SRC_DIR}/ada"
+: "${CPP_DIR:=${SRC_DIR}/cpp}"
+: "${ADA_DIR:=${SRC_DIR}/ada}"
 
-export UXAS_BIN="${OBJ_DIR}/cpp/uxas"
-export UXAS_ADA_BIN="${ADA_DIR}/uxas-ada"
+: "${UXAS_BIN:=${OBJ_DIR}/cpp/uxas}"
+: "${UXAS_ADA_BIN:=${ADA_DIR}/uxas-ada}"
 
-# For LmcpGen and OpenAMASE
-export SUPPORT_DIR="${OPENUXAS_ROOT}/develop"
-export LMCP_DIR="${SUPPORT_DIR}/LmcpGen"
-export AMASE_DIR="${SUPPORT_DIR}/OpenAMASE"
+: "${VPYTHON_DIR:=${OPENUXAS_ROOT}/.vpython}"
+: "${VPYTHON_ACTIVATE:=${VPYTHON_DIR}/bin/activate}"
 
-export VPYTHON_DIR="${OPENUXAS_ROOT}/.vpython"
-export VPYTHON_ACTIVATE="${VPYTHON_DIR}/bin/activate"
+: "${INSTALL_LIBEXEC_DIR:=${INFRASTRUCTURE_DIR}/install-libexec}"
+: "${SOFTWARE_DIR:=${INFRASTRUCTURE_DIR}/software}"
+: "${GNAT_DIR:=${SOFTWARE_DIR}/gnat}"
 
-export INSTALL_LIBEXEC_DIR="${INFRASTRUCTURE_DIR}/install-libexec"
-export SOFTWARE_DIR="${INFRASTRUCTURE_DIR}/software"
-export GNAT_DIR="${SOFTWARE_DIR}/gnat"
+: "${SPEC_DIR:=${INFRASTRUCTURE_DIR}/specs}"
+: "${SBX_DIR:=${INFRASTRUCTURE_DIR}/sbx}"
+: "${ARCH_DIR:=${SBX_DIR}/x86_64-linux}"
 
-export SPEC_DIR="${INFRASTRUCTURE_DIR}/specs"
-export SBX_DIR="${INFRASTRUCTURE_DIR}/sbx"
+: "${LMCP_DIR:=${ARCH_DIR}/lmcpgen/src}"
+: "${AMASE_DIR:=${ARCH_DIR}/amase/src}"
+
+: "${SUPPORT_DIR:=${OPENUXAS_ROOT}/develop}"
+: "${LMCP_DEVEL_DIR:=${SUPPORT_DIR}/LmcpGen}"
+: "${AMASE_DEVEL_DIR:=${SUPPORT_DIR}/OpenAMASE}"
 
 
 # Try to activate the python venv.

--- a/infrastructure/run_example.py
+++ b/infrastructure/run_example.py
@@ -15,8 +15,10 @@ from typing import TYPE_CHECKING
 import yaml
 
 from uxas.paths import (
+    ANOD_BIN,
     OPENUXAS_ROOT,
     EXAMPLES_DIR,
+    AMASE_DEVEL_DIR,
     AMASE_DIR,
     UXAS_BIN,
     UXAS_ADA_BIN,
@@ -36,10 +38,6 @@ if TYPE_CHECKING:
 
 # Relativized root
 REL_OPENUXAS_ROOT = os.path.relpath(OPENUXAS_ROOT)
-
-# Anod command
-ANOD_CMD = os.path.join(REL_OPENUXAS_ROOT, "anod")
-
 
 # Allow the environment to specify how long we should wait after starting an
 # instance of OpenAMASE; default to 0 seconds.
@@ -118,7 +116,7 @@ should:
 """
 
 UNBUILT_SPECIFIED_AMASE = """\
-The OpenAMASE path `%s exists, but hasn't been built. You should:
+The OpenAMASE path `%s` exists, but hasn't been built. You should:
 
     cd "%s/OpenAMASE" && ant
 
@@ -142,9 +140,9 @@ Trying the anod-built OpenAMASE as a fall back.
 """
 
 
-def check_amase_dir(path: str) -> bool:
-    """Test to make sure a path has the OpenUxAS build."""
-    return os.path.exists(os.path.join(path, "OpenAMASE", "build"))
+def check_amase_jar(path: str) -> bool:
+    """Test to make sure a path has the OpeAMASE jar."""
+    return os.path.exists(os.path.join(path, "OpenAMASE", "dist", "OpenAMASE.jar"))
 
 
 def resolve_amase_dir(args: Namespace) -> str:
@@ -160,26 +158,34 @@ def resolve_amase_dir(args: Namespace) -> str:
     immediately exit.
     """
     if args.amase_dir:
-        if check_amase_dir(args.amase_dir):
-            return args.amase_dir
-        else:
+        if not os.path.exists(args.amase_dir):
             logging.critical(
-                UNBUILT_SPECIFIED_AMASE, args.amase_dir, args.amase_dir, ANOD_CMD
+                "The specified OpenAMASE path `%s` doesn't exist.", args.amase_dir
             )
             sys.exit(1)
 
-    if os.path.exists(AMASE_DIR):
-        if check_amase_dir(AMASE_DIR):
-            return AMASE_DIR
-        else:
-            logging.warning(UNBUILT_LOCAL_AMASE, AMASE_DIR, AMASE_DIR, ANOD_CMD)
+        if check_amase_jar(args.amase_dir):
+            return args.amase_dir
 
-    anod_amase_dir = os.path.join(SBX_DIR, "x86_64-linux", "amase", "src")
-    if os.path.exists(anod_amase_dir) and check_amase_dir(anod_amase_dir):
-        return anod_amase_dir
-    else:
-        logging.critical(MISSING_AMASE, ANOD_CMD)
+        logging.critical(
+            UNBUILT_SPECIFIED_AMASE,
+            args.amase_dir,
+            args.amase_dir,
+            ANOD_BIN,
+        )
         sys.exit(1)
+
+    if os.path.exists(AMASE_DEVEL_DIR):
+        if check_amase_jar(AMASE_DEVEL_DIR):
+            return AMASE_DEVEL_DIR
+
+        logging.warning(UNBUILT_LOCAL_AMASE, AMASE_DEVEL_DIR, AMASE_DEVEL_DIR, ANOD_BIN)
+
+    if check_amase_jar(AMASE_DIR):
+        return AMASE_DIR
+
+    logging.critical(MISSING_AMASE, ANOD_BIN)
+    sys.exit(1)
 
 
 def list_examples(examples_dir: str) -> None:
@@ -198,14 +204,14 @@ def list_examples(examples_dir: str) -> None:
 
 def check_amase(
     loaded_yaml: Dict[str, Any], example_dir: str, args: Namespace
-) -> Tuple[Optional[str], int]:
+) -> Tuple[Optional[str], int, Optional[str]]:
     """
     Check the OpenAMASE configuration in the YAML and return the scenario file.
 
     If any errors are encountered, report them and immediately exit.
     """
     if AMASE_YAML_KEY not in loaded_yaml.keys():
-        return (None, 0)
+        return (None, 0, None)
 
     if SCENARIO_YAML_KEY not in loaded_yaml[AMASE_YAML_KEY].keys():
         logging.critical("OpenAMASE configuration must specify a scenario file.")
@@ -216,6 +222,8 @@ def check_amase(
         logging.critical("Specified scenario file '%s' does not exist.", scenario_file)
         sys.exit(1)
 
+    amase_dir = resolve_amase_dir(args)
+
     if args.amase_delay is not None:
         amase_delay = args.amase_delay
     elif DELAY_YAML_KEY in loaded_yaml[AMASE_YAML_KEY].keys():
@@ -223,7 +231,7 @@ def check_amase(
     else:
         amase_delay = AMASE_DELAY
 
-    return (scenario_file, amase_delay)
+    return (scenario_file, amase_delay, amase_dir)
 
 
 def run_amase(scenario_file: str, example_dir: str, amase_dir: str) -> subprocess.Popen:
@@ -242,7 +250,7 @@ def run_amase(scenario_file: str, example_dir: str, amase_dir: str) -> subproces
     ]
 
     logging.info(
-        "Running OpenAMASE in\n             %s\n" "         with scenario '%s'.",
+        "Running OpenAMASE in\n             %s\n         with scenario '%s'.",
         amase_dir,
         scenario_file,
     )
@@ -261,7 +269,7 @@ def check_uxas(loaded_yaml: Dict[str, Any], example_dir: str) -> List[Dict[str, 
 
     Calls `check_one_uxas` and thus may immediately exit.
     """
-    uxas_configs = list()
+    uxas_configs = []
 
     if UXASES_YAML_KEY in loaded_yaml.keys():
         for record in loaded_yaml[UXASES_YAML_KEY]:
@@ -302,10 +310,11 @@ def find_uxas_bin(bin_name: str) -> Optional[str]:
 
     if os.path.exists(local_bin_path):
         return local_bin_path
-    elif os.path.exists(anod_bin_path):
+
+    if os.path.exists(anod_bin_path):
         return anod_bin_path
-    else:
-        return None
+
+    return None
 
 
 MISSING_BIN = """\
@@ -345,7 +354,7 @@ def check_one_uxas(record: Dict[str, str], example_dir: str) -> Dict[str, str]:
 
     uxas_binary = find_uxas_bin(bin_name)
     if uxas_binary is None:
-        logging.critical(MISSING_BIN, bin_name, ANOD_CMD, bin_name)
+        logging.critical(MISSING_BIN, bin_name, ANOD_BIN, bin_name)
         sys.exit(1)
 
     return {
@@ -599,12 +608,13 @@ def run_example_main() -> int:
 
         loaded_yaml = read_yaml(yaml_filename)
 
-        amase_dir = resolve_amase_dir(args)
-        (scenario_file, amase_delay) = check_amase(loaded_yaml, example_dir, args)
+        (scenario_file, amase_delay, amase_dir) = check_amase(
+            loaded_yaml, example_dir, args
+        )
 
         uxas_configs = check_uxas(loaded_yaml, example_dir)
 
-        if scenario_file:
+        if scenario_file and amase_dir:
             amase_pid = run_amase(scenario_file, example_dir, amase_dir)
 
             if amase_delay > 0:

--- a/infrastructure/run_example.py
+++ b/infrastructure/run_example.py
@@ -141,7 +141,7 @@ Trying the anod-built OpenAMASE as a fall back.
 
 
 def check_amase_jar(path: str) -> bool:
-    """Test to make sure a path has the OpeAMASE jar."""
+    """Test to make sure a path has the OpenAMASE jar."""
     return os.path.exists(os.path.join(path, "OpenAMASE", "dist", "OpenAMASE.jar"))
 
 

--- a/infrastructure/uxas/src/uxas/paths.py
+++ b/infrastructure/uxas/src/uxas/paths.py
@@ -16,42 +16,95 @@ FALLBACK_REPO_DIR = os.path.realpath(__ROOT_DIR.split(".vpython")[0])
 
 # Now we read the environment and fall back on rebuilding the paths manually.
 OPENUXAS_ROOT = os.environ.get("OPENUXAS_ROOT", FALLBACK_REPO_DIR)
+"""Path to the root of the OpenUxAS repository."""
 
 ANOD_BIN = os.environ.get("ANOD_BIN", os.path.join(OPENUXAS_ROOT, "anod"))
+"""Path to the anod binary."""
 
 DOC_DIR = os.environ.get("DOC_DIR", os.path.join(OPENUXAS_ROOT, "doc"))
+"""Path to the documentation directory."""
+
 EXAMPLES_DIR = os.environ.get("EXAMPLES_DIR", os.path.join(OPENUXAS_ROOT, "examples"))
+"""Path to the examples directory."""
+
 INFRASTRUCTURE_DIR = os.environ.get(
     "INFRASTRUCTURE_DIR", os.path.join(OPENUXAS_ROOT, "infrastructure")
 )
+"""Path to the infrastructure directory."""
+
 MDMS_DIR = os.environ.get("MDMS_DIR", os.path.join(OPENUXAS_ROOT, "mdms"))
+"""Path to the (root) MDMs directory."""
+
 OBJ_DIR = os.environ.get("OBJ_DIR", os.path.join(OPENUXAS_ROOT, "obj"))
+"""Path to the object directory."""
+
 RESOURCES_DIR = os.environ.get(
     "RESOURCES_DIR", os.path.join(OPENUXAS_ROOT, "resources")
 )
+"""Path to the resources directory."""
+
 SRC_DIR = os.environ.get("SRC_DIR", os.path.join(OPENUXAS_ROOT, "src"))
+"""Path to the source directory."""
+
 TESTS_DIR = os.environ.get("TESTS_DIR", os.path.join(OPENUXAS_ROOT, "tests"))
+"""Path to the tests directory."""
 
 CPP_DIR = os.environ.get("CPP_DIR", os.path.join(SRC_DIR, "cpp"))
+"""Path to the C++ sources directory."""
+
 ADA_DIR = os.environ.get("ADA_DIR", os.path.join(SRC_DIR, "ada"))
+"""Path to the Ada sources directory."""
 
 UXAS_BIN = os.environ.get("UXAS_BIN", os.path.join(OPENUXAS_ROOT, "cpp", "uxas"))
-UXAS_ADA_BIN = os.environ.get("UXAS_ADA_BIN", os.path.join(ADA_DIR, "uxas-ada"))
+"""Path to the uxas binary."""
 
-# For LmcpGen and OpenAMASE
+UXAS_ADA_BIN = os.environ.get("UXAS_ADA_BIN", os.path.join(ADA_DIR, "uxas-ada"))
+"""Path to the uxas-ada binary."""
+
 SUPPORT_DIR = os.environ.get("SUPPORT_DIR", os.path.join(OPENUXAS_ROOT, "develop"))
-LMCP_DIR = os.environ.get("LMCP_DIR", os.path.join(SUPPORT_DIR, "LmcpGen"))
-AMASE_DIR = os.environ.get("AMASE_DIR", os.path.join(SUPPORT_DIR, "OpenAMASE"))
+"""Path to the support/development directory."""
+
+DEFAULT_LMCP_DEVEL_DIR = os.path.join(SUPPORT_DIR, "LmcpGen")
+"""Path the the default location of the LMCP development directory."""
+
+LMCP_DEVEL_DIR = os.environ.get("LMCP_DEVEL_DIR", DEFAULT_LMCP_DEVEL_DIR)
+"""Path to the LMCPgen development directory."""
+
+DEFAULT_AMASE_DEVEL_DIR = os.path.join(SUPPORT_DIR, "OpenAMASE")
+"""Path the the default location of the AMASE development directory."""
+
+AMASE_DEVEL_DIR = os.environ.get("AMASE_DEVEL_DIR", DEFAULT_AMASE_DEVEL_DIR)
+"""Path to the OpenAMASE development directory."""
 
 VPYTHON_DIR = os.environ.get("VPYTHON_DIR", os.path.join(OPENUXAS_ROOT, ".vpython"))
+"""Path to the vpython directory."""
+
 VPYTHON_ACTIVATE = os.environ.get(
     "VPYTHON_ACTIVATE", os.path.join(VPYTHON_DIR, "bin", "activate")
 )
+"""Path to the vpython activate script."""
 
 SOFTWARE_DIR = os.environ.get(
     "SOFTWARE_DIR", os.path.join(INFRASTRUCTURE_DIR, "software")
 )
+"""Path to the installed software directory."""
+
 GNAT_DIR = os.environ.get("GNAT_DIR", os.path.join(SOFTWARE_DIR, "gnat"))
+"""Path to the GNAT installation directory."""
 
 SPEC_DIR = os.environ.get("SPEC_DIR", os.path.join(INFRASTRUCTURE_DIR, "specs"))
+"""Path to the anod specs directory."""
+
 SBX_DIR = os.environ.get("SBX_DIR", os.path.join(INFRASTRUCTURE_DIR, "sbx"))
+"""Path to the sandbox directory."""
+
+AMASE_DIR = os.environ.get("AMASE_DIR", os.path.join(SBX_DIR, "amase", "src"))
+"""Path to the OpenAMASE source directory (in the sandbox)."""
+
+LMCP_DIR = os.environ.get("LMCP_DIR", os.path.join(SBX_DIR, "lmcpgen", "src"))
+"""Path to the LMCPgen source directory (in the sandbox)."""
+
+REPOSITORIES_YAML = os.environ.get(
+    "REPOSITORIES_YAML", os.path.join(SPEC_DIR, "config", "repositories.yaml")
+)
+"""Path to the repositories.yaml file."""


### PR DESCRIPTION
Fix Issues #45 and #44 

This commit makes a number of improvements.

1. Update paths.sh to allow env overrides

Previously, paths.sh set path variables without checking to see if they
had already been set by the user. This is now fixed: if the variable is
already set, that value will be used. Otherwise, the default value will
be used.

This will allow the user to more easily steer the behavior of the
infrastructure (although care must be taken to ensure that values
provided in the environment make sense).

2. Update paths.py with docstrings and to match paths.sh

3. Update run_example.py

Some minor problems in run_example are resolved / cleaned up. There is
likely more work to be done here; this is a complex file.

4. Update run_lmcpgen.py

Significant improvements to usability through better handling of paths
and better error reporting.

run_lmcpgen will now run LmcpGen from:
  1. command-line argument - building if needed
  2. explicit environment variable (LMCP_DEVEL_DIR) - building if needed
  3. directory spec'd in repositories.yaml - building if needed
  4. sanbox - failing if not already build

run_lmcpgen will build for OpenAMASE if -a is given, building in:
  1. command-line argument
  2. explicit environment variable (AMASE_DEVEL_DIR)
  3. directory spec'd in repositories.yaml

OpenAMASE in the sandbox is not used, as changes would be overwritten on
next anod build.