### PR TITLE
e3-core API changes

### DIFF
--- a/infrastructure/uxas/setup.py
+++ b/infrastructure/uxas/setup.py
@@ -2,8 +2,8 @@
 from setuptools import setup, find_packages
 
 install_requires = [
-    "e3-core",
-    "e3-testsuite",
+    "e3-core==22.1.0",
+    "e3-testsuite==24.0",
     "pyzmq",
 ]
 

--- a/infrastructure/uxas/setup.py
+++ b/infrastructure/uxas/setup.py
@@ -2,8 +2,8 @@
 from setuptools import setup, find_packages
 
 install_requires = [
-    "e3-core==22.1.0",
-    "e3-testsuite==24.0",
+    "e3-core",
+    "e3-testsuite",
     "pyzmq",
 ]
 

--- a/infrastructure/uxas/src/uxas/anod/build.py
+++ b/infrastructure/uxas/src/uxas/anod/build.py
@@ -63,7 +63,7 @@ def add_anod_files_to_fingerprint(
 
 class UxasEmptyJob(EmptyJob):
     def __init__(self, uid, data, notify_end, sandbox):
-        super(UxasEmptyJob, self).__init__(uid, data, notify_end)
+        super(UxasEmptyJob, self).__init__(uid, data, notify_end, ReturnValue.skip)
 
 
 class UxasJob(Job):

--- a/infrastructure/uxas/src/uxas/anod/util.py
+++ b/infrastructure/uxas/src/uxas/anod/util.py
@@ -45,8 +45,7 @@ def create_anod_context(spec_dir: str) -> AnodContext:
 
 
 def create_anod_sandbox(sbx_dir: str, spec_dir: str) -> SandBox:
-    sbx = SandBox()
-    sbx.root_dir = sbx_dir
+    sbx = SandBox(sbx_dir)
     sbx.specs_dir = spec_dir
 
     return sbx

--- a/infrastructure/uxas/src/uxas/cli/build.py
+++ b/infrastructure/uxas/src/uxas/cli/build.py
@@ -16,7 +16,6 @@ from e3.main import Main
 # Define what we mean by a successful build.
 BUILD_SUCCESS = [
     ReturnValue.success,
-    ReturnValue.force_skip,
     ReturnValue.skip,
     ReturnValue.unchanged,
 ]


### PR DESCRIPTION
Fix some minor API changes in e3-core due to recent update to `v22.2.0`.

@manthonyaiello the only change I was unsure of was the following.  For the `UxasEmptyJob` python class I added the return value of `skip` where it was defaulted to `force_skip` before (which has been deprecated).  Is this the correct subsitution?