### PR TITLE
fix issues #57 and #62

### DIFF
--- a/.github/workflows/amase.yaml
+++ b/.github/workflows/amase.yaml
@@ -21,20 +21,22 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+                env: [
+                    {os: ubuntu-20.04, python: '3.8'},
+                    {os: ubuntu-22.04, python: '3.10'}
+                ]
                 component: [amase]
                 qualifier: [scenario=release]
-                python-version: [3.7, 3.8]
-        runs-on: ${{ matrix.os }}
+        runs-on: ${{ matrix.env.os }}
         steps:
             - uses: actions/checkout@v2
               with:
                   path: OpenUxAS
 
-            - name: Set up python ${{ matrix.python-version }}
+            - name: Set up python ${{ matrix.env.python }}
               uses: actions/setup-python@v2
               with:
-                  python-version: ${{ matrix.python-version }}
+                  python-version: ${{ matrix.env.python }}
 
             - name: Set up java
               uses: actions/setup-java@v1

--- a/.github/workflows/infrastructure-install.yaml
+++ b/.github/workflows/infrastructure-install.yaml
@@ -15,18 +15,20 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-                python-version: [3.7, 3.8]
-        runs-on: ${{ matrix.os }}
+                env: [
+                    {os: ubuntu-20.04, python: '3.8'},
+                    {os: ubuntu-22.04, python: '3.10'}
+                ]
+        runs-on: ${{ matrix.env.os }}
         steps:
             - uses: actions/checkout@v2
               with:
                   path: OpenUxAS
 
-            - name: Set up python ${{ matrix.python-version }}
+            - name: Set up python ${{ matrix.env.python }}
               uses: actions/setup-python@v2
               with:
-                  python-version: ${{ matrix.python-version }}
+                  python-version: ${{ matrix.env.python }}
 
             - name: Set up testing tools
               run: |

--- a/.github/workflows/run-example.yaml
+++ b/.github/workflows/run-example.yaml
@@ -27,18 +27,20 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-                python-version: [3.7, 3.8]
-        runs-on: ${{ matrix.os }}
+                env: [
+                    {os: ubuntu-20.04, python: '3.8'},
+                    {os: ubuntu-22.04, python: '3.10'}
+                ]
+        runs-on: ${{ matrix.env.os }}
         steps:
             - uses: actions/checkout@v2
               with:
                   path: OpenUxAS
 
-            - name: Set up python ${{ matrix.python-version }}
+            - name: Set up python ${{ matrix.env.python }}
               uses: actions/setup-python@v2
               with:
-                  python-version: ${{ matrix.python-version }}
+                  python-version: ${{ matrix.env.python }}
 
             - name: Set up java
               uses: actions/setup-java@v1

--- a/.github/workflows/run-lmcpgen.yaml
+++ b/.github/workflows/run-lmcpgen.yaml
@@ -23,18 +23,20 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-                python-version: [3.7, 3.8]
-        runs-on: ${{ matrix.os }}
+                env: [
+                    {os: ubuntu-20.04, python: '3.8'},
+                    {os: ubuntu-22.04, python: '3.10'}
+                ]
+        runs-on: ${{ matrix.env.os }}
         steps:
             - uses: actions/checkout@v2
               with:
                   path: OpenUxAS
 
-            - name: Set up python ${{ matrix.python-version }}
+            - name: Set up python ${{ matrix.env.python }}
               uses: actions/setup-python@v2
               with:
-                  python-version: ${{ matrix.python-version }}
+                  python-version: ${{ matrix.env.python }}
 
             - name: Set up java
               uses: actions/setup-java@v1

--- a/.github/workflows/uxas-ada.yaml
+++ b/.github/workflows/uxas-ada.yaml
@@ -24,20 +24,22 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+                env: [
+                    {os: ubuntu-20.04, python: '3.8'},
+                    {os: ubuntu-22.04, python: '3.10'}
+                ]
                 component: [uxas-ada]
                 qualifier: [scenario=release]
-                python-version: [3.7, 3.8]
-        runs-on: ${{ matrix.os }}
+        runs-on: ${{ matrix.env.os }}
         steps:
             - uses: actions/checkout@v2
               with:
                   path: OpenUxAS
 
-            - name: Set up python ${{ matrix.python-version }}
+            - name: Set up python ${{ matrix.env.python }}
               uses: actions/setup-python@v2
               with:
-                  python-version: ${{ matrix.python-version }}
+                  python-version: ${{ matrix.env.python }}
 
             - name: Set up java
               uses: actions/setup-java@v1

--- a/.github/workflows/uxas-cpp.yaml
+++ b/.github/workflows/uxas-cpp.yaml
@@ -24,20 +24,22 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+                env: [
+                    {os: ubuntu-20.04, python: '3.8'},
+                    {os: ubuntu-22.04, python: '3.10'}
+                ]
                 component: [uxas]
                 qualifier: [scenario=release, scenario=gcov]
-                python-version: [3.7, 3.8]
-        runs-on: ${{ matrix.os }}
+        runs-on: ${{ matrix.env.os }}
         steps:
             - uses: actions/checkout@v2
               with:
                   path: OpenUxAS
 
-            - name: Set up python ${{ matrix.python-version }}
+            - name: Set up python ${{ matrix.env.python }}
               uses: actions/setup-python@v2
               with:
-                  python-version: ${{ matrix.python-version }}
+                  python-version: ${{ matrix.env.python }}
 
             - name: Set up java
               uses: actions/setup-java@v1

--- a/.github/workflows/uxas-module.yaml
+++ b/.github/workflows/uxas-module.yaml
@@ -15,18 +15,20 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
-                python-version: [3.7, 3.8]
-        runs-on: ${{ matrix.os }}
+                env: [
+                    {os: ubuntu-20.04, python: '3.8'},
+                    {os: ubuntu-22.04, python: '3.10'}
+                ]
+        runs-on: ${{ matrix.env.os }}
         steps:
             - uses: actions/checkout@v2
               with:
                   path: OpenUxAS
 
-            - name: Set up python ${{ matrix.python-version }}
+            - name: Set up python ${{ matrix.env.python }}
               uses: actions/setup-python@v2
               with:
-                  python-version: ${{ matrix.python-version }}
+                  python-version: ${{ matrix.env.python }}
 
             - name: Set up testing tools
               run: |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you would like to copy-paste commands from this README, you should only copy 
 We've tried to make getting started with OpenUxAS as simple as possible.
 Before you begin, you will need:
 
-1. Ubuntu 20.04
+1. Ubuntu 22.04 or 20.04
 2. git
 
 Use git to clone this repository:


### PR DESCRIPTION
This PR fixes #57 and fixes #62 by:

* removing Ubuntu 18.04
* pairing Ubuntu 20.04 with Python 3.8 and Ubuntu 22.04 with Python 3.10

The result is a much leaner matrix for CI that should still be representative of expected use.