### PR TITLE
Remove "using namespace" usage in header files, fix includes ordering.

### DIFF
--- a/src/cpp/Communications/ImpactSubscribePushBridge.cpp
+++ b/src/cpp/Communications/ImpactSubscribePushBridge.cpp
@@ -8,6 +8,8 @@
 // ===============================================================================
 
 
+#include "ImpactSubscribePushBridge.h"
+#include "ZeroMqFabric.h"
 #include "UxAS_ConfigurationManager.h"
 #include "UxAS_Log.h"
 #include "Constants/UxAS_String.h"
@@ -17,8 +19,6 @@
 #include <sstream>
 #include <iostream>
 #include <locale>
-#include "ZeroMqFabric.h"
-#include "ImpactSubscribePushBridge.h"
 
 #define STRING_XML_SUBSCRIBE_TO_EXTERNAL_MESSAGE "SubscribeToExternalMessage"
 

--- a/src/cpp/Communications/LmcpObjectMessageReceiverPipe.cpp
+++ b/src/cpp/Communications/LmcpObjectMessageReceiverPipe.cpp
@@ -8,18 +8,16 @@
 // ===============================================================================
 
 #include "LmcpObjectMessageReceiverPipe.h"
-
 #include "LmcpMessage.h"
 #include "MessageAttributes.h"
 #include "ZeroMqSocketConfiguration.h"
+#include "UxAS_Log.h"
+#include "Constants/UxAS_String.h"
+#include "stdUniquePtr.h"
 
 #include "avtas/lmcp/ByteBuffer.h"
 #include "avtas/lmcp/Factory.h"
 
-#include "UxAS_Log.h"
-#include "Constants/UxAS_String.h"
-
-#include "stdUniquePtr.h"
 
 namespace uxas
 {

--- a/src/cpp/Communications/LmcpObjectMessageSenderPipe.cpp
+++ b/src/cpp/Communications/LmcpObjectMessageSenderPipe.cpp
@@ -8,17 +8,14 @@
 // ===============================================================================
 
 #include "LmcpObjectMessageSenderPipe.h"
+#include "ZeroMqSocketConfiguration.h"
+#include "SerialHelper.h"
+#include "Constants/UxAS_String.h"
+#include "stdUniquePtr.h"
 
 #include "avtas/lmcp/ByteBuffer.h"
 #include "avtas/lmcp/Factory.h"
 
-#include "ZeroMqSocketConfiguration.h"
-
-#include "SerialHelper.h"
-
-#include "Constants/UxAS_String.h"
-
-#include "stdUniquePtr.h"
 
 namespace uxas
 {

--- a/src/cpp/Communications/LmcpObjectMessageTcpReceiverSenderPipe.cpp
+++ b/src/cpp/Communications/LmcpObjectMessageTcpReceiverSenderPipe.cpp
@@ -8,18 +8,16 @@
 // ===============================================================================
 
 #include "LmcpObjectMessageTcpReceiverSenderPipe.h"
-
 #include "LmcpMessage.h"
 #include "MessageAttributes.h"
 #include "ZeroMqSocketConfiguration.h"
+#include "UxAS_Log.h"
+#include "Constants/UxAS_String.h"
+#include "stdUniquePtr.h"
 
 #include "avtas/lmcp/ByteBuffer.h"
 #include "avtas/lmcp/Factory.h"
 
-#include "UxAS_Log.h"
-#include "Constants/UxAS_String.h"
-
-#include "stdUniquePtr.h"
 
 namespace uxas
 {

--- a/src/cpp/Communications/LmcpObjectNetworkBridgeManager.cpp
+++ b/src/cpp/Communications/LmcpObjectNetworkBridgeManager.cpp
@@ -9,22 +9,19 @@
 
 #include "LmcpObjectNetworkBridgeManager.h"
 #include "ServiceManager.h"
-
 #include "LmcpObjectNetworkSerialBridge.h"
 #include "LmcpObjectNetworkTcpBridge.h"
 #include "LmcpObjectNetworkSubscribePushBridge.h"
 #include "LmcpObjectNetworkPublishPullBridge.h"
 #include "LmcpObjectNetworkZeroMqZyreBridge.h"
-
 #include "UxAS_ConfigurationManager.h"
 #include "Constants/UxAS_String.h"
 #include "UxAS_Log.h"
-#include "uxas/messages/uxnative/KillService.h"
-
 #include "stdUniquePtr.h"
-
 #include "LmcpObjectNetworkSerialBridge.h"
 #include "ImpactSubscribePushBridge.h"
+
+#include "uxas/messages/uxnative/KillService.h"
 
 #include <fstream>
 #include <stdexcept>

--- a/src/cpp/Communications/LmcpObjectNetworkClientBase.cpp
+++ b/src/cpp/Communications/LmcpObjectNetworkClientBase.cpp
@@ -8,16 +8,16 @@
 // ===============================================================================
 
 #include "LmcpObjectNetworkClientBase.h"
-
-#include "avtas/lmcp/ByteBuffer.h"
-#include "avtas/lmcp/Factory.h"
-#include "uxas/messages/uxnative/KillService.h"
-
 #include "UxAS_ConfigurationManager.h"
 #include "UxAS_Log.h"
 #include "Constants/UxAS_String.h"
-
 #include "stdUniquePtr.h"
+
+#include "uxas/messages/uxnative/KillService.h"
+
+#include "avtas/lmcp/ByteBuffer.h"
+#include "avtas/lmcp/Factory.h"
+
 
 namespace uxas
 {

--- a/src/cpp/Communications/LmcpObjectNetworkTcpBridge.cpp
+++ b/src/cpp/Communications/LmcpObjectNetworkTcpBridge.cpp
@@ -9,15 +9,13 @@
 
 #include "LmcpObjectNetworkTcpBridge.h"
 #include "ZmqAttributedMsgSenderReceiver.h"
-
-#include "avtas/lmcp/Factory.h"
-
 #include "UxAS_ConfigurationManager.h"
 #include "UxAS_Log.h"
 #include "Constants/UxAS_String.h"
 #include "UxAS_Time.h"
-
 #include "stdUniquePtr.h"
+
+#include "avtas/lmcp/Factory.h"
 
 #include <chrono>
 #include <sstream>

--- a/src/cpp/Communications/LmcpObjectNetworkZeroMqZyreBridge.cpp
+++ b/src/cpp/Communications/LmcpObjectNetworkZeroMqZyreBridge.cpp
@@ -8,17 +8,14 @@
 // ===============================================================================
 
 #include "LmcpObjectNetworkZeroMqZyreBridge.h"
+#include "UxAS_Log.h"
+#include "Constants/UxAS_String.h"
+#include "stdUniquePtr.h"
+#include "Constants/Constant_Strings.h"
+#include "Constants/Constants_Control.h"
 
 #include "uxas/messages/uxnative/EntityJoin.h"
 #include "uxas/messages/uxnative/EntityExit.h"
-
-#include "UxAS_Log.h"
-#include "Constants/UxAS_String.h"
-
-#include "stdUniquePtr.h"
-
-#include "Constants/Constant_Strings.h"
-#include "Constants/Constants_Control.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/cpp/Communications/SerialHelper.h
+++ b/src/cpp/Communications/SerialHelper.h
@@ -10,10 +10,10 @@
 #ifndef UXAS_MESSAGE_DATA_SERIAL_HELPER_H
 #define UXAS_MESSAGE_DATA_SERIAL_HELPER_H
 
+#include "stdUniquePtr.h"
+
 #include "afrl/cmasi/KeyValuePair.h"
 #include "afrl/cmasi/ServiceStatus.h"
-
-#include "stdUniquePtr.h"
 
 #include <sstream>
 

--- a/src/cpp/Communications/ZeroMq/Sockets/ZmqSocketInitializer.cpp
+++ b/src/cpp/Communications/ZeroMq/Sockets/ZmqSocketInitializer.cpp
@@ -7,9 +7,9 @@
 // Title 17, U.S. Code.  All Other Rights Reserved.
 // ===============================================================================
 
+#include "ZmqSocketInitializer.h"
 #include "ZeroMqFabric.h"
 #include "TransportBase.h"
-#include "ZmqSocketInitializer.h"
 #include "UxAS_Log.h"
 
 namespace uxas {

--- a/src/cpp/Communications/ZeroMq/ZmqAttributedMsgSenderReceiver.cpp
+++ b/src/cpp/Communications/ZeroMq/ZmqAttributedMsgSenderReceiver.cpp
@@ -7,12 +7,12 @@
 // Title 17, U.S. Code.  All Other Rights Reserved.
 // ===============================================================================
 
+#include "ZmqAttributedMsgSenderReceiver.h"
 #include "MsgSenderSentinel.h"
 #include "MsgReceiverSentinel.h"
 #include "ZmqPullReceiver.h"
 #include "ZmqPushSender.h"
 #include "ZmqTcpSenderReceiver.h"
-#include "ZmqAttributedMsgSenderReceiver.h"
 
 #include "UxAS_ConfigurationManager.h"
 

--- a/src/cpp/Communications/ZeroMq/ZmqAttributedMsgSenderReceiver.h
+++ b/src/cpp/Communications/ZeroMq/ZmqAttributedMsgSenderReceiver.h
@@ -13,6 +13,7 @@
 #include "ZmqProxy.h"
 #include "AddressedAttributedMessage.h"
 #include "IMsgSenderReceiver.h"
+#include "UxAS_SentinelSerialBuffer.h"
 
 #include <string>
 #include <thread>

--- a/src/cpp/Communications/ZeroMq/ZmqPushSender.cpp
+++ b/src/cpp/Communications/ZeroMq/ZmqPushSender.cpp
@@ -7,8 +7,8 @@
 // Title 17, U.S. Code.  All Other Rights Reserved.
 // ===============================================================================
 
-#include "ZmqSocketBase.h"
 #include "ZmqPushSender.h"
+#include "ZmqSocketBase.h"
 #include "ZmqSocketInitializer.h"
 #include "UxAS_Log.h"
 

--- a/src/cpp/Communications/ZeroMqAddressedAttributedMessageReceiver.h
+++ b/src/cpp/Communications/ZeroMqAddressedAttributedMessageReceiver.h
@@ -10,12 +10,11 @@
 #ifndef UXAS_MESSAGE_TRANSPORT_ZERO_MQ_ADDRESSED_ATTRIBUTED_MESSAGE_RECEIVER_H
 #define UXAS_MESSAGE_TRANSPORT_ZERO_MQ_ADDRESSED_ATTRIBUTED_MESSAGE_RECEIVER_H
 
-#include <deque>
 #include "ZeroMqReceiverBase.h"
-
 #include "AddressedAttributedMessage.h"
-
 #include "UxAS_SentinelSerialBuffer.h"
+
+#include <deque>
 
 namespace uxas
 {

--- a/src/cpp/Communications/ZeroMqAddressedAttributedMessageTcpReceiverSender.h
+++ b/src/cpp/Communications/ZeroMqAddressedAttributedMessageTcpReceiverSender.h
@@ -10,13 +10,15 @@
 #ifndef UXAS_MESSAGE_TRANSPORT_ZERO_MQ_ADDRESSED_ATTRIBUTED_MESSAGE_TCP_RECEIVER_SENDER_H
 #define UXAS_MESSAGE_TRANSPORT_ZERO_MQ_ADDRESSED_ATTRIBUTED_MESSAGE_TCP_RECEIVER_SENDER_H
 
-#include <deque>
-#include <vector>
-#include <mutex>
-#include "czmq.h"
 #include "ZeroMqReceiverBase.h"
 #include "AddressedAttributedMessage.h"
 #include "UxAS_SentinelSerialBuffer.h"
+
+#include "czmq.h"
+
+#include <deque>
+#include <vector>
+#include <mutex>
 
 namespace uxas
 {

--- a/src/cpp/Communications/ZeroMqSocketConfiguration.h
+++ b/src/cpp/Communications/ZeroMqSocketConfiguration.h
@@ -10,8 +10,9 @@
 #ifndef UXAS_MESSAGE_TRANSPORT_ZERO_MQ_SOCKET_CONFIGURATION_H
 #define UXAS_MESSAGE_TRANSPORT_ZERO_MQ_SOCKET_CONFIGURATION_H
 
-#include <cstdint>
 #include "SocketConfiguration.h"
+
+#include <cstdint>
 
 namespace uxas
 {

--- a/src/cpp/DPSS/CoordinateConversions.cpp
+++ b/src/cpp/DPSS/CoordinateConversions.cpp
@@ -9,6 +9,7 @@
 
 #include "Dpss.h"
 using namespace std;
+using namespace Dpss_Data_n;
 
 int Dpss::UavWpToVscsWp(int uavWp)
 {

--- a/src/cpp/DPSS/DRand.cpp
+++ b/src/cpp/DPSS/DRand.cpp
@@ -10,10 +10,10 @@
 // DRand.cpp : Various random number generators
 // Contributed by Derek Kingston
 
-#include <cmath>
-#include <ctime> 
 #include "DRand.h"
 
+#include <cmath>
+#include <ctime> 
 // generates a value in [0,1] distributed uniformly
 double randu() { return (rand() + 0.0)/RAND_MAX; }
 

--- a/src/cpp/DPSS/Dpss.cpp
+++ b/src/cpp/DPSS/Dpss.cpp
@@ -9,6 +9,7 @@
 
 #include "Dpss.h"
 using namespace std;
+using namespace Dpss_Data_n;
 
 Dpss::Dpss()
 {

--- a/src/cpp/DPSS/Dpss.h
+++ b/src/cpp/DPSS/Dpss.h
@@ -17,6 +17,7 @@
 #include "VehicleTelemetry.h"
 #include "VehiclePoint.h"
 #include "UnitConversions.h"
+
 #include <string>
 #include <vector>
 #include <time.h>
@@ -55,7 +56,7 @@ public:
   void SetObjective(DpssWaypoint pathPoints[], int numPathPoints, DpssWaypoint planPoints[], int numPlanPoints, ObjectiveParameters* op);
 
   // overloaded function to allow for direct xy access
-  void SetObjective(std::vector<xyPoint>& path, std::vector<xyPoint>& plan,    ObjectiveParameters* op);
+  void SetObjective(std::vector<Dpss_Data_n::xyPoint>& path, std::vector<Dpss_Data_n::xyPoint>& plan,    ObjectiveParameters* op);
 
   //  Adds the vehicles specified in the vehicleIds array to the system.
   //
@@ -120,15 +121,15 @@ public:
 
   
   // take optimized central plan and offset for look angle
-  void OffsetPlanForward(std::vector<xyPoint> &xyPlanPoints, std::vector<xyPoint> &forwardPlan);
-  void OffsetPlanReverse(std::vector<xyPoint> &xyPlanPoints, std::vector<xyPoint> &reversePlan);
+  void OffsetPlanForward(std::vector<Dpss_Data_n::xyPoint> &xyPlanPoints, std::vector<Dpss_Data_n::xyPoint> &forwardPlan);
+  void OffsetPlanReverse(std::vector<Dpss_Data_n::xyPoint> &xyPlanPoints, std::vector<Dpss_Data_n::xyPoint> &reversePlan);
 
   // builds x,y road from lat/lon coordinates and removes nonsense segments
-  void PreProcessPath(DpssWaypoint pathPoints[], int numPoints, std::vector<xyPoint>& xyPathPoints);
-  void PreProcessPath(std::vector<xyPoint>& xyPathPoints);
+  void PreProcessPath(DpssWaypoint pathPoints[], int numPoints, std::vector<Dpss_Data_n::xyPoint>& xyPathPoints);
+  void PreProcessPath(std::vector<Dpss_Data_n::xyPoint>& xyPathPoints);
 
   // greedy method for selecting center waypoints from a given road input
-  void PlanQuickly(std::vector<xyPoint> &xyPoints, int maxWps);
+  void PlanQuickly(std::vector<Dpss_Data_n::xyPoint> &xyPoints, int maxWps);
 
 #ifdef AFRL_INTERNAL_ENABLED
   // accurate method for selecting center waypoints from a given road input
@@ -136,11 +137,11 @@ public:
 #endif
 
   // removes road points that lie outside of comm range
-  void RemoveRoadPointsOutOfCommRange(std::vector<xyPoint>& xyPathPoints);
+  void RemoveRoadPointsOutOfCommRange(std::vector<Dpss_Data_n::xyPoint>& xyPathPoints);
 
   // cuts waypoints that are within 'threshold' distance of other waypoints
   // basically, declutters the plan
-  void PostProcessPlan(std::vector<xyPoint>& plan, double threshold);
+  void PostProcessPlan(std::vector<Dpss_Data_n::xyPoint>& plan, double threshold);
 
   // alerts the algorithm that the path is circular not linear
   void SetSingleDirectionPlanning(bool val);
@@ -149,13 +150,13 @@ public:
   bool GetSingleDirectionPlanning();
 
   // helper function to break large road task into smaller sub-tasks
-  void RoadPosToWpSegments(xyPoint roadPt, xyPoint& forwardPt, xyPoint& reversePt, int& forwardIndexA, int& forwardIndexB, int& reverseIndexA, int& reverseIndexB);
+  void RoadPosToWpSegments(Dpss_Data_n::xyPoint roadPt, Dpss_Data_n::xyPoint& forwardPt, Dpss_Data_n::xyPoint& reversePt, int& forwardIndexA, int& forwardIndexB, int& reverseIndexA, int& reverseIndexB);
 
   // uses mapping to steer camera
   void CalculateStarePoint(VehiclePoint &starePoint, VehicleTelemetry &vehiclePosition);
 
   // overloaded for xypoints, forces global search
-  void CalculateStarePoint(xyPoint &starePoint, xyPoint &vehiclePosition);
+  void CalculateStarePoint(Dpss_Data_n::xyPoint &starePoint, Dpss_Data_n::xyPoint &vehiclePosition);
 
   void SetNominalAzimuth_rad(double& dNominalAzimuth_rad)
   {
@@ -176,16 +177,16 @@ private:
     void UpdateLinearization(DpssWaypoint points[], int numPoints);
 
     // removes redundant points from a list - guarantees no zero length segments
-    void RemoveZeroLengthSegments(std::vector<xyPoint> &xyPoints);
+    void RemoveZeroLengthSegments(std::vector<Dpss_Data_n::xyPoint> &xyPoints);
 
     // build full plan from forward and reverse plans and format in lat/lon
-    void CombinePlans(std::vector<xyPoint> &forwardPlan, std::vector<xyPoint> &reversePlan, DpssWaypoint* outputPoints, int* numOutputPoints);
+    void CombinePlans(std::vector<Dpss_Data_n::xyPoint> &forwardPlan, std::vector<Dpss_Data_n::xyPoint> &reversePlan, DpssWaypoint* outputPoints, int* numOutputPoints);
 
     // assumes uniform speed camera motion and generates stare points for all waypoints
-    void CorrespondingStarePoints(std::vector<xyPoint>& plan, std::vector<xyPoint>& road, std::vector<xyPoint>& starePoints);
+    void CorrespondingStarePoints(std::vector<Dpss_Data_n::xyPoint>& plan, std::vector<Dpss_Data_n::xyPoint>& road, std::vector<Dpss_Data_n::xyPoint>& starePoints);
 
     // cuts waypoints that cause stare point crossing
-    void CleanUpStareAngles(std::vector<xyPoint>& plan, std::vector<xyPoint>& road);
+    void CleanUpStareAngles(std::vector<Dpss_Data_n::xyPoint>& plan, std::vector<Dpss_Data_n::xyPoint>& road);
 
     // Sets up optimization class to find center waypoints in normalized coordinates
     double PathOptimization(std::vector<double>& x);
@@ -200,7 +201,7 @@ private:
     double AngleToCurrentSegment(VehicleTelemetry& uav);
 
     // helper function to translate from telemetry to xy plane
-    int CurrentSegmentAndXYPosition(VehicleTelemetry& uav, xyPoint& xyPos, Segment& currentSegment);
+    int CurrentSegmentAndXYPosition(VehicleTelemetry& uav, Dpss_Data_n::xyPoint& xyPos, Dpss_Data_n::Segment& currentSegment);
 
     // coordinate transformations
     int UavWpToVscsWp(int uavWp);
@@ -215,18 +216,18 @@ private:
     double RoadIndexToNormalizedRoadPos(int roadIndex);
     int NormalizedRoadPosToClosestRoadIndex(double normalizedRoadPos);
 
-    double NormalizedRoadPosToVehiclePos(xyPoint& p, double normalizedRoadPos, int direction);
-    double VehiclePosToNormalizedRoadPos(xyPoint& vehiclePos);
+    double NormalizedRoadPosToVehiclePos(Dpss_Data_n::xyPoint& p, double normalizedRoadPos, int direction);
+    double VehiclePosToNormalizedRoadPos(Dpss_Data_n::xyPoint& vehiclePos);
     
-    void RoadIndexToVehiclePos(xyPoint& p, int roadIndex, int direction);
-    int VehiclePosToRoadIndex(xyPoint& vehiclePos);
+    void RoadIndexToVehiclePos(Dpss_Data_n::xyPoint& p, int roadIndex, int direction);
+    int VehiclePosToRoadIndex(Dpss_Data_n::xyPoint& vehiclePos);
 
     // specialized coordinate transformations
-    int NormalizedRoadPosToXyRoadPos(xyPoint& p, double x);
+    int NormalizedRoadPosToXyRoadPos(Dpss_Data_n::xyPoint& p, double x);
     double CorrespondingNormalizedRoadLocation(VehicleTelemetry &pos);
 public:    //RAS
     unsigned short NormalizedRoadPosToVscsWp(double roadPos, int direction);
-    double CorrespondingNormalizedRoadLocation(xyPoint &pos);
+    double CorrespondingNormalizedRoadLocation(Dpss_Data_n::xyPoint &pos);
 private:    //RAS
 
     // Central method to whole operation
@@ -237,12 +238,12 @@ private:    //RAS
     // methods for optimizing look angle mapping for input road and waypoints
     double SensorPointingCostForward(std::vector<double>& x);
     double SensorPointingCostReverse(std::vector<double>& x);
-    double ComputeSeperation(double& beta, xyPoint& a, xyPoint& b, xyPoint& c);
+    double ComputeSeperation(double& beta, Dpss_Data_n::xyPoint& a, Dpss_Data_n::xyPoint& b, Dpss_Data_n::xyPoint& c);
     double MaxDeviation(double a, double b);
     
     // debug functions for showing results of calculations
-    void PrintRoadXY(char fileName[], std::vector<xyPoint> &road);
-    void PrintRoadXYZ(char fileName[], std::vector<xyPoint> &road);
+    void PrintRoadXY(char fileName[], std::vector<Dpss_Data_n::xyPoint> &road);
+    void PrintRoadXYZ(char fileName[], std::vector<Dpss_Data_n::xyPoint> &road);
     void PrintRoadLatLon(char fileName[], DpssWaypoint* wp, int numWps);
     void FullDebugPlan();
     
@@ -269,11 +270,11 @@ private:    //RAS
 
     double m_LreLatitudeInRadians;
     double m_LreLongitudeInRadians;
-    xyPoint m_LaunchRecoveryPoint;
+    Dpss_Data_n::xyPoint m_LaunchRecoveryPoint;
 
     double m_LostCommPointLatitudeInRadians;
     double m_LostCommPointLongitudeInRadians;
-    xyPoint m_LostCommPoint;
+    Dpss_Data_n::xyPoint m_LostCommPoint;
 
 
     /////// Bookkeeping:Planning ///////
@@ -285,7 +286,7 @@ private:    //RAS
     // full input road in x,y coordinates
     // initialized in PreProcessPath
     // used by CleanUpStareAngles
-    std::vector<xyPoint> m_PlanningRoad;
+    std::vector<Dpss_Data_n::xyPoint> m_PlanningRoad;
 
     // input road indices that correspond to points *not* removed in the quick planning stage
     // initialized in PlanQuickly
@@ -295,7 +296,7 @@ private:    //RAS
     // full input road in x,y coordinates
     // initialized in PlanPrecisely
     // used in CandidateCost to compute deviation from candidate and actual roads
-    std::vector<xyPoint> m_PrecisePlanRoad;
+    std::vector<Dpss_Data_n::xyPoint> m_PrecisePlanRoad;
 
     // mapping of input x,y road to normalized length [0...1]
     // initialized in PlanPrecisely
@@ -309,7 +310,7 @@ private:    //RAS
     std::vector<DpssWaypoint> m_LatLonWaypoints;
 
     // x,y coordinates of waypoints loaded to UAV
-    std::vector<xyPoint> m_TrueWaypoints;
+    std::vector<Dpss_Data_n::xyPoint> m_TrueWaypoints;
 
     // corresponding waypoint indices loaded to UAV
     std::vector<int> m_WpIDList;
@@ -318,7 +319,7 @@ private:    //RAS
     std::vector<DpssWaypoint> m_LatLonRoad;
 
     // actual x,y input road coordinates for steering
-    std::vector<xyPoint> m_TrueRoad;
+    std::vector<Dpss_Data_n::xyPoint> m_TrueRoad;
 
     // normalized coordinates along input road [0...1]
     std::vector<double> m_TrueRoadLengths;

--- a/src/cpp/DPSS/DpssDataTypes.cpp
+++ b/src/cpp/DPSS/DpssDataTypes.cpp
@@ -9,6 +9,8 @@
 
 #include "DpssDataTypes.h"
 
+using namespace Dpss_Data_n;
+
 void xyPoint::Rotate(double th)
 {
     xyPoint t(x,y);

--- a/src/cpp/DPSS/DpssDataTypes.h
+++ b/src/cpp/DPSS/DpssDataTypes.h
@@ -108,5 +108,3 @@ public:
 
 
 };    //namespace Dpss_Data
-
-using namespace Dpss_Data_n;

--- a/src/cpp/DPSS/DpssUtilities.cpp
+++ b/src/cpp/DPSS/DpssUtilities.cpp
@@ -9,11 +9,13 @@
 
 #include "Dpss.h"
 #include "DRand.h"
+
 #include <iostream>
 #include <fstream>
 //#include <direct.h> //_mkdir
 
 using namespace std;
+using namespace Dpss_Data_n;
 
 double Dpss::DistanceToCurrentSegment(VehicleTelemetry& uav)
 {

--- a/src/cpp/DPSS/PlanOffset.cpp
+++ b/src/cpp/DPSS/PlanOffset.cpp
@@ -9,6 +9,7 @@
 
 #include "Dpss.h"
 using namespace std;
+using namespace Dpss_Data_n;
 
 void Dpss::OffsetPlanForward(std::vector<xyPoint> &xyPlanPoints, std::vector<xyPoint> &forwardPlan)
 {

--- a/src/cpp/DPSS/PlanPrecisely.cpp
+++ b/src/cpp/DPSS/PlanPrecisely.cpp
@@ -8,8 +8,11 @@
 // ===============================================================================
 
 #include "Dpss.h"
+
 #include <algorithm>
+
 using namespace std;
+using namespace Dpss_Data_n;
 
 double Dpss::PlanCost(std::vector<double>& x)
 {

--- a/src/cpp/DPSS/PlanQuickly.cpp
+++ b/src/cpp/DPSS/PlanQuickly.cpp
@@ -8,7 +8,9 @@
 // ===============================================================================
 
 #include "Dpss.h"
+
 using namespace std;
+using namespace Dpss_Data_n;
 
 void Dpss::PlanQuickly(std::vector<xyPoint>& xyPoints, int maxWps)
 {

--- a/src/cpp/DPSS/SegmentMap.cpp
+++ b/src/cpp/DPSS/SegmentMap.cpp
@@ -9,6 +9,8 @@
 
 #include "SegmentMap.h"
 
+using namespace Dpss_Data_n;
+
 SegmentMap::SegmentMap()
 {
     totalPlanLength = 0.0;

--- a/src/cpp/DPSS/SegmentMap.h
+++ b/src/cpp/DPSS/SegmentMap.h
@@ -9,23 +9,23 @@
 
 #pragma once
 #include "DpssDataTypes.h"
-#include <vector>
 
+#include <vector>
 class SegmentMap
 {
 public:
     SegmentMap();
-    SegmentMap(std::vector<xyPoint>& uavPlan, std::vector<xyPoint>& road);
+    SegmentMap(std::vector<Dpss_Data_n::xyPoint>& uavPlan, std::vector<Dpss_Data_n::xyPoint>& road);
     ~SegmentMap();
 
-    void Initialize(std::vector<xyPoint>& uavPlan, std::vector<xyPoint>& road);
-    xyPoint CalculateStarePoint(xyPoint& uavLoc);
-    static xyPoint CalculateStarePoint(std::vector<xyPoint>& uavPlan, std::vector<xyPoint>& road, xyPoint& uavLoc);
-    static int SnapToSegment(std::vector<xyPoint>& polyline, xyPoint& actualLocation, xyPoint& snappedLocation);
+    void Initialize(std::vector<Dpss_Data_n::xyPoint>& uavPlan, std::vector<Dpss_Data_n::xyPoint>& road);
+    Dpss_Data_n::xyPoint CalculateStarePoint(Dpss_Data_n::xyPoint& uavLoc);
+    static Dpss_Data_n::xyPoint CalculateStarePoint(std::vector<Dpss_Data_n::xyPoint>& uavPlan, std::vector<Dpss_Data_n::xyPoint>& road, Dpss_Data_n::xyPoint& uavLoc);
+    static int SnapToSegment(std::vector<Dpss_Data_n::xyPoint>& polyline, Dpss_Data_n::xyPoint& actualLocation, Dpss_Data_n::xyPoint& snappedLocation);
 
 private:
-    std::vector<xyPoint> path;
-    std::vector<xyPoint> plan;
+    std::vector<Dpss_Data_n::xyPoint> path;
+    std::vector<Dpss_Data_n::xyPoint> plan;
     std::vector<double> normalizedPathLengths;
     double totalPlanLength;
     double totalPathLength;

--- a/src/cpp/DPSS/SensorSteering2.cpp
+++ b/src/cpp/DPSS/SensorSteering2.cpp
@@ -8,11 +8,14 @@
 // ===============================================================================
 
 #include "Dpss.h"
+
 #include <algorithm>
 #include <functional>
 #include <iostream>
 #include <fstream>
+
 using namespace std;
+using namespace Dpss_Data_n;
 
 void Dpss::CalculateStarePoint(VehiclePoint &starePoint, VehicleTelemetry &vehiclePosition)
 {

--- a/src/cpp/Includes/Constants/Constants_Control.h
+++ b/src/cpp/Includes/Constants/Constants_Control.h
@@ -17,8 +17,8 @@
 #ifndef CONSTANTS_CONTROL_H
 #define    CONSTANTS_CONTROL_H
 
-#include <string>
 #include "Constants/Constant_Strings.h"
+#include <string>
 
 namespace n_Const
 {   

--- a/src/cpp/Includes/TypeDefs/UxAS_TypeDefs_ZeroMQ.h
+++ b/src/cpp/Includes/TypeDefs/UxAS_TypeDefs_ZeroMQ.h
@@ -17,9 +17,9 @@
 #ifndef UXAS_TYPEDEFS_ZEROMQ_H
 #define    UXAS_TYPEDEFS_ZEROMQ_H
 
-#include <memory>       //std::shared_ptr
-
 #include "zmq.hpp"
+
+#include <memory>       //std::shared_ptr
 
 namespace n_Typedefs
 {

--- a/src/cpp/Plans/Assignment.h
+++ b/src/cpp/Plans/Assignment.h
@@ -32,11 +32,9 @@
 //#include "TrajectoryDefinitions.h"
 #include "BaseObject.h"
 #include "Waypoint.h"
-
 #include "TaskAssignment.h"
 
 #include <assert.h>
-
 namespace n_FrameworkLib
 {
 
@@ -139,12 +137,12 @@ namespace n_FrameworkLib
             return (iIndex);
         }
 
-        bool bSaveWaypointsToMatlabMatrix(ofstream& ofstrMatlabFile) {
+        bool bSaveWaypointsToMatlabMatrix(std::ofstream& ofstrMatlabFile) {
             bool bReturn(false); //will return true if there are any waypoints to print
             if (!vwayGetWaypoints().empty()) {
                 ofstrMatlabFile << " [ ...";
                 for (V_WAYPOINT_CONST_IT_t itWaypoint = itGetWaypointBegin(); itWaypoint != itGetWaypointEnd(); itWaypoint++) {
-                    ofstrMatlabFile << endl << *itWaypoint;
+                    ofstrMatlabFile << std::endl << *itWaypoint;
                 }
                 ofstrMatlabFile << "]";
                 bReturn = true;

--- a/src/cpp/Plans/CGrid.h
+++ b/src/cpp/Plans/CGrid.h
@@ -37,11 +37,11 @@
 /****************************************************
 *                    Includes                        *
 *****************************************************/
+//#include "GlobalDefines.h"    //V_INT_t, V_POSITION_t
+#include "Position.h"
+
 #include <vector>
 #include <string>
-//#include "GlobalDefines.h"    //V_INT_t, V_POSITION_t
-using namespace std;
-#include "Position.h"
 
 /* test if a & b are within epsilon.  Favors cases where a < b */
 #define Near(a,b,eps)    ( ((b)-(eps)<(a)) && ((a)-(eps)<(b)) )
@@ -65,8 +65,8 @@ private:
         CPosition VertexB;
     };    //Only create if needed...
     
-    typedef vector<CellData> VData;
-    typedef vector<CellData>::iterator VDataIterator;
+    typedef std::vector<CellData> VData;
+    typedef std::vector<CellData>::iterator VDataIterator;
     
     VDataIterator DIndex;
     VDataIterator DUpperBound;
@@ -78,8 +78,8 @@ private:
         VData *Data ;                            // make pointer because doesn't always exist
     };    // always create 
     
-    typedef vector<Cell> VCell;
-    typedef vector<Cell>::iterator VCellIterator;
+    typedef std::vector<Cell> VCell;
+    typedef std::vector<Cell>::iterator VCellIterator;
     
     VCell VGrid;
     VCellIterator    Index;
@@ -124,10 +124,10 @@ private:
     *************************************************/
 private:
     
-    void Setup_Corner_Value(stringstream &sstrErrorMessage);
+    void Setup_Corner_Value(std::stringstream &sstrErrorMessage);
     
     bool Setup_GridData(Cell &Cur_Cell, double xa, double ya, double xb, double yb, 
-        CPosition &vtxa, CPosition &vtxb, stringstream &sstrErrorMessage);
+        CPosition &vtxa, CPosition &vtxb, std::stringstream &sstrErrorMessage);
     
     void Print();
     
@@ -144,11 +144,11 @@ public:
     // default constructor
     CGrid(std::vector<int32_t>& viVerticies,V_POSITION_t& vposVertexContainer, int x_grid_resolution, 
         int y_grid_resolution, CPosition &min, CPosition &max,
-        stringstream &sstrErrorMessage );
+        std::stringstream &sstrErrorMessage );
     
     ~CGrid();                                                //Destructor
     
-    bool InPolygon(double x, double y, double z, const CPosition &min, stringstream &sstrErrorMessage);
+    bool InPolygon(double x, double y, double z, const CPosition &min, std::stringstream &sstrErrorMessage);
     
     };
 

--- a/src/cpp/Plans/Polygon.cpp
+++ b/src/cpp/Plans/Polygon.cpp
@@ -29,13 +29,14 @@
 //#pragma warning(disable:4786)
 #define DEBUG_FLAG 0
 #define METHOD_DEBUG 0
+
 #include "Polygon.h"
-#include <iostream>
-#include <sstream>
-#include <math.h>
 //#include "GlobalDefines.h"
 #include "CGrid.h"
 
+#include <iostream>
+#include <sstream>
+#include <math.h>
 using namespace std;
 
 namespace n_FrameworkLib

--- a/src/cpp/Plans/Polygon.h
+++ b/src/cpp/Plans/Polygon.h
@@ -36,23 +36,24 @@
 #pragma once
 #endif // _MSC_VER > 1000
 
-//#include "GlobalDefines.h"    //V_INT_t
 
+
+
+
+//#include "GlobalDefines.h"    //V_INT_t
 #include "Position.h"
 #include "Edge.h"
 #include "CGrid.h"
 #include "visilibity.h"     //polygon expansion
 
-
 #include "afrl/cmasi/AbstractZone.h"
-#
+
+#include "boost/dynamic_bitset.hpp"    //use  id bits for local ID
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #endif//_WIN32
-
-#include "boost/dynamic_bitset.hpp"    //use  id bits for local ID
 #include <unordered_map>
 #include <list>
 #include <utility>    //pair
@@ -248,14 +249,14 @@ public:    //typedefs
 
     typedef CPolygonType::enPolygonType enPolygonType;
 
-    typedef vector<CPolygon> V_POLYGON_t;
-    typedef vector<CPolygon>::iterator V_POLYGON_IT_t;
-    typedef vector<CPolygon>::const_iterator V_POLYGON_CONST_IT_t;
+    typedef std::vector<CPolygon> V_POLYGON_t;
+    typedef std::vector<CPolygon>::iterator V_POLYGON_IT_t;
+    typedef std::vector<CPolygon>::const_iterator V_POLYGON_CONST_IT_t;
 
-    typedef pair <int,V_POLYGON_IT_t> PAIR_INT_ITPOLYGON_t;
-    typedef multimap<int,V_POLYGON_IT_t> MMAP_INT_ITPOLYGON_t;
-    typedef multimap<int,V_POLYGON_IT_t>::iterator MMAP_INT_ITPOLYGON_IT_t;
-    typedef multimap<int,V_POLYGON_IT_t>::const_iterator MMAP_INT_ITPOLYGON_CONST_IT_t;
+    typedef std::pair <int,V_POLYGON_IT_t> PAIR_INT_ITPOLYGON_t;
+    typedef std::multimap<int,V_POLYGON_IT_t> MMAP_INT_ITPOLYGON_t;
+    typedef std::multimap<int,V_POLYGON_IT_t>::iterator MMAP_INT_ITPOLYGON_IT_t;
+    typedef std::multimap<int,V_POLYGON_IT_t>::const_iterator MMAP_INT_ITPOLYGON_CONST_IT_t;
 
     typedef boost::dynamic_bitset<> DYNAMIC_BITSET_t;
 
@@ -359,7 +360,7 @@ public:    //constructors/destructors
 
 public:    //methods/functions
 
-    void StreamPolygonPython(ostream &os, V_POSITION_t& vposVerticiesBase)
+    void StreamPolygonPython(std::ostream &os, V_POSITION_t& vposVerticiesBase)
     {
         for (CEdge::V_EDGE_CONST_IT_t itEdge = veGetPolygonEdges().begin(); itEdge != veGetPolygonEdges().end(); itEdge++)
         {
@@ -380,7 +381,7 @@ public:    //methods/functions
         }
     };
 
-    void StreamPolygonMatlab(ostream &os, V_POSITION_t& vposVerticiesBase)
+    void StreamPolygonMatlab(std::ostream &os, V_POSITION_t& vposVerticiesBase)
     {
         for (CEdge::V_EDGE_CONST_IT_t itEdge = veGetPolygonEdges().begin(); itEdge != veGetPolygonEdges().end(); itEdge++)
         {
@@ -401,19 +402,19 @@ public:    //methods/functions
         }
     };
 
-    void StreamPolygonCPP(ostream &os, V_POSITION_t& vposVerticiesBase)
+    void StreamPolygonCPP(std::ostream &os, V_POSITION_t& vposVerticiesBase)
     {
-        os << "//add polygon ID:[" << iGetID() <<"]" << endl;
-        os << "vposVerticies.clear();" << endl;
-        os << "iID = " << iGetID() << ";" << endl;
+        os << "//add polygon ID:[" << iGetID() <<"]" << std::endl;
+        os << "vposVerticies.clear();" << std::endl;
+        os << "iID = " << iGetID() << ";" << std::endl;
         for(CEdge::V_EDGE_CONST_IT_t itEdge=veGetPolygonEdges().begin();itEdge!=veGetPolygonEdges().end();itEdge++)
         {
             os << "vposVerticies.push_back(CPosition(" << vposVerticiesBase[static_cast<unsigned int>(itEdge->first)].m_north_m 
                 << "," 
-                << vposVerticiesBase[static_cast<unsigned int>(itEdge->first)].m_east_m << "));" << endl;
+                << vposVerticiesBase[static_cast<unsigned int>(itEdge->first)].m_east_m << "));" << std::endl;
         }
-        os << "errAddPolygon = visibilityGraph.errAddPolygon(iID,vposVerticies.begin(),vposVerticies.end());" << endl;
-        os << "visibilityGraph.vplygnGetPolygons().back().plytypGetPolygonType().bGetKeepIn() = false;" << endl << endl;
+        os << "errAddPolygon = visibilityGraph.errAddPolygon(iID,vposVerticies.begin(),vposVerticies.end());" << std::endl;
+        os << "visibilityGraph.vplygnGetPolygons().back().plytypGetPolygonType().bGetKeepIn() = false;" << std::endl << std::endl;
     };
 
     void ResetPolygon()
@@ -723,7 +724,7 @@ private:
     *                Private Member Functions        *
     *************************************************/
 private:
-    void GridTest(const double x, const double y,const double z,V_POSITION_t& vposVertexContainer,stringstream &sstrErrorMessage);
+    void GridTest(const double x, const double y,const double z,V_POSITION_t& vposVertexContainer,std::stringstream &sstrErrorMessage);
     // copy constructor - make unusable to prevent bad things from happening
     //CPolygon(const CPolygon& Polygon) {};
     //// assignment operator - make unusable to prevent bad things from happening
@@ -735,17 +736,17 @@ private:
     *************************************************/
 public:    
     bool InPolygon(const double x, const double y, 
-        const double z,V_POSITION_t& vposVertexContainer, stringstream &sstrErrorMessage);
+        const double z,V_POSITION_t& vposVertexContainer, std::stringstream &sstrErrorMessage);
 
-    void FindPolygonBoundingBox(V_POSITION_t& vposVertexContainer,stringstream &sstrErrorMessage);
+    void FindPolygonBoundingBox(V_POSITION_t& vposVertexContainer,std::stringstream &sstrErrorMessage);
 
     bool PointInBoundingBox(const double x, const double y, 
-        const double z, stringstream &sstrErrorMessage); 
+        const double z, std::stringstream &sstrErrorMessage); 
 
 };
 
 
-ostream &operator << (ostream &os,const CPolygon& polyRhs);
+std::ostream &operator << (std::ostream &os,const CPolygon& polyRhs);
 
 };      ///namespace n_FrameworkLib
 

--- a/src/cpp/Plans/Position.h
+++ b/src/cpp/Plans/Position.h
@@ -142,7 +142,6 @@ namespace n_FrameworkLib
         };
 
         double relativeDistance2D_m(const CPosition& posPoint) {
-            using namespace std;
 
             // returns the distance between this point and another
             double dNorth = m_north_m - posPoint.m_north_m;
@@ -152,7 +151,6 @@ namespace n_FrameworkLib
         };
 
         double relativeDistance2D_m(const CPosition& posPoint)const {
-            using namespace std;
 
             // returns the distance between this point and another
             double dNorth = m_north_m - posPoint.m_north_m;
@@ -162,7 +160,6 @@ namespace n_FrameworkLib
         };
 
         double manhattanDistance_m(const CPosition& posPoint)const {
-            using namespace std;
 
             // returns the Manhattan distance between this point and another
             double north_m = m_north_m - posPoint.m_north_m;

--- a/src/cpp/Plans/VehicleBase.h
+++ b/src/cpp/Plans/VehicleBase.h
@@ -68,7 +68,7 @@ public:
 				m_bUseTaskEligibility(false),
 				m_dHeadingInitial_rad(dPsi_rad)
     {
-        stringstream sstrFileName;
+        std::stringstream sstrFileName;
         sstrFileName << "V_" << iGetID();
         strGetBaseFileName() = sstrFileName.str();
     };
@@ -81,7 +81,7 @@ public:
 		m_bUseTaskEligibility(false),
 		m_dHeadingInitial_rad(0.0)
     {
-        stringstream sstrFileName;
+        std::stringstream sstrFileName;
         sstrFileName << "V_" << iGetID();
         strGetBaseFileName() = sstrFileName.str();
     };
@@ -94,7 +94,7 @@ public:
 		m_bUseTaskEligibility(false),
 		m_dHeadingInitial_rad(0.0)
     {
-        stringstream sstrFileName;
+        std::stringstream sstrFileName;
         sstrFileName << "V_" << iGetID();
         strGetBaseFileName() = sstrFileName.str();
     };
@@ -107,7 +107,7 @@ public:
 		m_bUseTaskEligibility(false),
 		m_dHeadingInitial_rad(0.0)
     {
-        stringstream sstrFileName;
+        std::stringstream sstrFileName;
         sstrFileName << "V_" << iGetID();
         strGetBaseFileName() = sstrFileName.str();
     };
@@ -140,7 +140,7 @@ public:
         vuiGetTaskEligibility() = rhs.vuiGetTaskEligibility();
         bGetUseTaskEligibility() = rhs.bGetUseTaskEligibility();
         strGetBaseFileName() = rhs.strGetBaseFileName();
-        stringstream sstrFileName;
+        std::stringstream sstrFileName;
         sstrFileName << "V_" << rhs.iGetID();
         strGetBaseFileName() = sstrFileName.str();
         dGetHeadingInitial_rad() = rhs.dGetHeadingInitial_rad();
@@ -243,11 +243,11 @@ public: //accessors
         return (m_bUseTaskEligibility);
     };
 
-    string& strGetBaseFileName() {
+    std::string& strGetBaseFileName() {
         return (m_strBaseFileName);
     };
 
-    const string& strGetBaseFileName()const {
+    const std::string& strGetBaseFileName()const {
         return (m_strBaseFileName);
     };
 

--- a/src/cpp/Plans/VehicleParameters.h
+++ b/src/cpp/Plans/VehicleParameters.h
@@ -563,7 +563,7 @@ namespace n_FrameworkLib
     };
 
 
-    ostream &operator <<(ostream &os, const CVehicleParameters& vehprmRhs);
+    std::ostream &operator <<(std::ostream &os, const CVehicleParameters& vehprmRhs);
 
 
 } //namespace n_FrameworkLib

--- a/src/cpp/Plans/VisibilityGraph.cpp
+++ b/src/cpp/Plans/VisibilityGraph.cpp
@@ -39,6 +39,7 @@
 
 #include <pugixml.hpp>
 
+using namespace std;
 
 namespace n_FrameworkLib
 {

--- a/src/cpp/Plans/VisibilityGraph.h
+++ b/src/cpp/Plans/VisibilityGraph.h
@@ -27,9 +27,7 @@
 
 #pragma once
 
-
 #include "Polygon.h"
-
 #include "VehicleBase.h"
 #include "PlanningParameters.h"
 #include "TrajectoryParameters.h"
@@ -43,14 +41,12 @@
 #include "boost/graph/dijkstra_shortest_paths.hpp"
 #include "boost/graph/johnson_all_pairs_shortest.hpp"
 
+
 #include <iostream>
 #include <iomanip>
 #include <fstream>
 #include <ostream>
-using std::ostream;
 #include <complex>
-using std::complex;
-
 #include <memory>       //std::shared_ptr
 
 namespace n_FrameworkLib
@@ -95,7 +91,7 @@ namespace n_FrameworkLib
         typedef std::deque<CPosition>::const_iterator D_POSITION_CONST_IT_t;
         typedef std::shared_ptr<D_POSITION_t> PTR_DEQUE_POSITION_t;
 
-        typedef complex<double> COMPLEX_D_t;
+        typedef std::complex<double> COMPLEX_D_t;
 
         typedef std::shared_ptr<uxas::messages::route::GraphRegion> PTR_GRAPH_REGION_t;
         typedef std::map<uint32_t, PTR_GRAPH_REGION_t> M_UI32_PTR_GRAPH_REGION_t;
@@ -147,7 +143,7 @@ namespace n_FrameworkLib
         enError errExpandAndMergePolygons(void);
         enError errBuildVisibilityGraph(void);
         enError errBuildVisibilityGraph(PTR_GRAPH_REGION_t& ptr_GraphRegion);
-        enError errBuildVisibilityGraphWithOsm(const string& osmFile);
+        enError errBuildVisibilityGraphWithOsm(const std::string& osmFile);
         
 
         bool isFindPath(std::shared_ptr<CPathInformation>& pathInformation);
@@ -166,7 +162,7 @@ namespace n_FrameworkLib
 
         
         enError errInitializeGraphBase();
-        bool bBoundaryViolationExists(const V_WAYPOINT_t& vWaypoints, stringstream& sstrErrorMessage);
+        bool bBoundaryViolationExists(const V_WAYPOINT_t& vWaypoints, std::stringstream& sstrErrorMessage);
 
         enError errSmoothPath(D_POSITION_t& dposPath, const double& dTurnRadius_m,
                 double& dHeadingInitial_rad, double& dHeadingFinal_rad, V_WAYPOINT_t& vwayWaypoints);
@@ -281,7 +277,7 @@ namespace n_FrameworkLib
             return (errReturn);
         };
 
-        void StreamPolygons(ostream &os) {
+        void StreamPolygons(std::ostream &os) {
             os << "{";
             for (V_POLYGON_IT_t itPolygon = vplygnGetPolygons().begin(); itPolygon != vplygnGetPolygons().end(); itPolygon++) {
                 os << "[";
@@ -292,7 +288,7 @@ namespace n_FrameworkLib
             os << "}";
         };
 
-        void StreamPolygonsPython(ostream &os) {
+        void StreamPolygonsPython(std::ostream &os) {
             for (V_POLYGON_IT_t itPolygon = vplygnGetPolygons().begin(); itPolygon != vplygnGetPolygons().end(); itPolygon++) {
                 //os << "[";
                 itPolygon->StreamPolygonPython(os, vposGetVerticiesBase());
@@ -300,14 +296,14 @@ namespace n_FrameworkLib
             }
         };
 
-        void StreamPolygonsCPP(ostream &os) {
-            os << endl;
+        void StreamPolygonsCPP(std::ostream &os) {
+            os << std::endl;
             for (V_POLYGON_IT_t itPolygon = vplygnGetPolygons().begin(); itPolygon != vplygnGetPolygons().end(); itPolygon++) {
                 itPolygon->StreamPolygonCPP(os, vposGetVerticiesBase());
                 os << std::endl;
                 ;
             }
-            os << endl;
+            os << std::endl;
         };
 
         //void StreamEdgesCurrent(ostream &os)
@@ -326,8 +322,8 @@ namespace n_FrameworkLib
         //    os << "]";
         //};
 
-        void SaveGraphVizFileShortestPaths(const int& iIndexVertex, const string& strPathOutput, const string& strFileName = string("VisibilityGraphShortestPath.dot")) {
-            string strPathFileName = strPathOutput + "\\" + strFileName;
+        void SaveGraphVizFileShortestPaths(const int& iIndexVertex, const std::string& strPathOutput, const std::string& strFileName = "VisibilityGraphShortestPath.dot") {
+            std::string strPathFileName = strPathOutput + "\\" + strFileName;
             std::ofstream dot_file(strPathFileName.c_str());
 
             dot_file << "digraph D {\n"
@@ -339,7 +335,7 @@ namespace n_FrameworkLib
 
             boost::graph_traits < GRAPH_LIST_VEC_t >::vertex_iterator vi, vend;
 #if !defined(WIN32)
-            for (tie(vi, vend) = vertices(edglstvecGetGraph()); vi != vend; ++vi)
+            for (std::tie(vi, vend) = vertices(edglstvecGetGraph()); vi != vend; ++vi)
 #else
             for (std::tie(vi, vend) = vertices(edglstvecGetGraph()); vi != vend; ++vi)
 #endif
@@ -356,8 +352,8 @@ namespace n_FrameworkLib
             dot_file << "}";
         }
 
-        void SaveGraphVizFileFull(const string& strPathOutput, const string& strFileName = string("VisibilityGraphFull.dot")) {
-            string strPathFileName = strPathOutput + "\\" + strFileName;
+        void SaveGraphVizFileFull(const std::string& strPathOutput, const std::string& strFileName = "VisibilityGraphFull.dot") {
+            std::string strPathFileName = strPathOutput + "\\" + strFileName;
             std::ofstream dot_file(strPathFileName.c_str());
 
             dot_file << "digraph D {\n"
@@ -794,6 +790,6 @@ namespace n_FrameworkLib
         int m_iLengthSegmentMinimum;
     };
 
-    ostream &operator<<(ostream &os, const CVisibilityGraph& visgRhs);
+    std::ostream &operator<<(std::ostream &os, const CVisibilityGraph& visgRhs);
 
 }; //namespace n_FrameworkLib

--- a/src/cpp/Plans/Waypoint.cpp
+++ b/src/cpp/Plans/Waypoint.cpp
@@ -13,6 +13,8 @@
 
 #include "Waypoint.h"
 
+using namespace std;
+
 namespace n_FrameworkLib
 {
 

--- a/src/cpp/Plans/Waypoint.h
+++ b/src/cpp/Plans/Waypoint.h
@@ -28,41 +28,36 @@
 #pragma once
 #endif // _MSC_VER > 1000
 
-
-#include <limits>
-using namespace std;
-
-#include <memory>    //std::shared_ptr
-#include "afrl/cmasi/Waypoint.h"
-
-
 //#include "GlobalDefines.h"
 #include "UnitConversions.h"
 #include "Position.h"
 #include "Circle.h"
 
+#include "afrl/cmasi/Waypoint.h"
+
+#include <limits>
 #include <ostream>
-//using std::ostream;
 #include <map>
+#include <memory>    //std::shared_ptr
 
 // TODO: remove all waypoint mangling
 #define TASK_ID_MULTIPLIER 10000    // use this to make the waypoint index visible in the mangeled id (up to 9999 waypoints)
 
 namespace n_FrameworkLib
 {
-    
+
     typedef std::shared_ptr<afrl::cmasi::Waypoint> PTR_CMASI_WAYPOINT_t;
 
 class CWaypoint;
 
-typedef vector<CWaypoint> V_WAYPOINT_t;
+typedef std::vector<CWaypoint> V_WAYPOINT_t;
 typedef V_WAYPOINT_t::iterator V_WAYPOINT_IT_t;
 typedef V_WAYPOINT_t::const_iterator V_WAYPOINT_CONST_IT_t;
 typedef V_WAYPOINT_t::reverse_iterator V_WAYPOINT_REVERSE_IT_t;
 
-typedef map<int,CWaypoint> M_I_WAYPOINT_t;
-typedef map<int,CWaypoint>::iterator M_I_WAYPOINT_IT_t;
-typedef map<int,CWaypoint>::const_iterator M_I_WAYPOINT_CONST_IT_t;
+typedef std::map<int,CWaypoint> M_I_WAYPOINT_t;
+typedef std::map<int,CWaypoint>::iterator M_I_WAYPOINT_IT_t;
+typedef std::map<int,CWaypoint>::const_iterator M_I_WAYPOINT_CONST_IT_t;
 
 class CDataPoint : public CPosition
 {
@@ -206,13 +201,12 @@ public:    //member functions
 
     double reRelativeDistance2D(const CWaypointSmall& wayPoint )
     {
-        using namespace std;
 
         // returns the distance between this waypoint and another
         double dX = m_north_m - wayPoint.m_north_m; 
         double dY = m_east_m - wayPoint.m_east_m; 
 
-        return(sqrt((dX*dX) + (dY*dY)));
+        return(std::sqrt((dX*dX) + (dY*dY)));
     };
 
 
@@ -300,9 +294,9 @@ public:
     };
 
 public:
-    typedef numeric_limits<double> NUMERIC_LIMITS_double;
+    typedef std::numeric_limits<double> NUMERIC_LIMITS_double;
 
-    typedef vector<CWaypoint> V_WAYPOINT_t;
+    typedef std::vector<CWaypoint> V_WAYPOINT_t;
     typedef V_WAYPOINT_t::iterator V_WAYPOINT_IT_t;
     typedef V_WAYPOINT_t::const_iterator V_WAYPOINT_CONST_IT_t;
 
@@ -496,7 +490,7 @@ public:    //constructors
         CWaypointSmall::operator =(rhs);
     };
     
-    void osStreamWaypointHeadings(ostream &os); 
+    void osStreamWaypointHeadings(std::ostream &os); 
     
 
     bool bIsWaypointEligibleForRemoval()
@@ -510,9 +504,9 @@ public:    //constructors
         return(bReturn);
     }
 
-    string strGetType()
+    std::string strGetType()
     {
-        string strWaypointType("wayTypeUnknown");
+        std::string strWaypointType("wayTypeUnknown");
         switch(typeGetWaypoint())
         {
         case waytypeSearch:
@@ -800,7 +794,7 @@ public:
 };
 
 
-ostream &operator << (ostream &os,const CWaypoint& wayRhs);
+std::ostream &operator << (std::ostream &os,const CWaypoint& wayRhs);
 
 };      //namespace n_FrameworkLib
 

--- a/src/cpp/Services/AdapterServiceHelper.h
+++ b/src/cpp/Services/AdapterServiceHelper.h
@@ -10,6 +10,8 @@
 #ifndef UXAS_SERVICE_ADAPTER_ADAPTER_SERVICE_HELPER_H
 #define UXAS_SERVICE_ADAPTER_ADAPTER_SERVICE_HELPER_H
 
+#include "stdUniquePtr.h"
+
 #include "afrl/cmasi/AirVehicleConfiguration.h"
 #include "afrl/cmasi/AirVehicleState.h"
 #include "afrl/cmasi/KeyValuePair.h"
@@ -17,9 +19,6 @@
 #include "afrl/cmasi/MissionCommand.h"
 #include "afrl/cmasi/ServiceStatus.h"
 
-#include "../../common/log/Log.h"
-
-#include "../../stduxas/stdUniquePtr.h"
 
 namespace uxas
 {

--- a/src/cpp/Services/AssignmentTreeBranchBoundBase.cpp
+++ b/src/cpp/Services/AssignmentTreeBranchBoundBase.cpp
@@ -16,18 +16,17 @@
 
 
 #include "AssignmentTreeBranchBoundBase.h"
-
 #include "TimeUtilities.h"
 #include "Constants/Constant_Strings.h"
 
-#include "afrl/cmasi/ServiceStatus.h"
 #include "uxas/messages/task/TaskAssignmentSummary.h"
 #ifdef AFRL_INTERNAL_ENABLED
 #include "uxas/project/pisr/PSIR_AssignmentType.h"
 #endif
 
-#include "pugixml.hpp"
+#include "afrl/cmasi/ServiceStatus.h"
 
+#include "pugixml.hpp"
 
 #include <sstream>      //std::stringstream
 #include <iostream>     // std::cout, cerr, etc

--- a/src/cpp/Services/AutomationDiagramDataService.cpp
+++ b/src/cpp/Services/AutomationDiagramDataService.cpp
@@ -16,8 +16,12 @@
 
 
 #include "AutomationDiagramDataService.h"
-
 #include "FileSystemUtilities.h"
+#include "TimeUtilities.h"
+#include "Constants/Convert.h"
+
+#include "uxas/messages/task/SensorFootprintResponse.h"
+#include "uxas/messages/task/SensorFootprint.h"
 
 #include "afrl/cmasi/EntityState.h"
 #include "afrl/cmasi/EntityStateDescendants.h"
@@ -25,19 +29,11 @@
 #include "afrl/cmasi/KeepInZone.h"
 #include "afrl/cmasi/KeepOutZone.h"
 #include "afrl/cmasi/CameraConfiguration.h"
-
 #include "afrl/cmasi/Task.h"
 #include "afrl/cmasi/TaskDescendants.h"  
-
-#include "uxas/messages/task/SensorFootprintResponse.h"
-#include "uxas/messages/task/SensorFootprint.h"
-
 #include "afrl/impact/PointOfInterest.h"
 #include "afrl/impact/LineOfInterest.h"
 #include "afrl/impact/AreaOfInterest.h"
-
-#include "TimeUtilities.h"
-#include "Constants/Convert.h"
 
 #include "pugixml.hpp"
 

--- a/src/cpp/Services/AutomationDiagramDataService.h
+++ b/src/cpp/Services/AutomationDiagramDataService.h
@@ -21,19 +21,18 @@
 
 #include "ServiceBase.h"
 
-#include "afrl/cmasi/EntityState.h"
-#include "afrl/cmasi/Task.h"
-#include "afrl/cmasi/OperatingRegion.h"
-#include "afrl/cmasi/AbstractZone.h"
-
-#include "afrl/impact/AreaOfInterest.h"
-#include "afrl/impact/LineOfInterest.h"
-#include "afrl/impact/PointOfInterest.h"
-
 #include "uxas/messages/task/SensorFootprintRequests.h"
 #include "uxas/messages/task/SensorFootprint.h"
 #include "uxas/messages/task/UniqueAutomationRequest.h"
 #include "uxas/messages/task/UniqueAutomationResponse.h"
+
+#include "afrl/cmasi/EntityState.h"
+#include "afrl/cmasi/Task.h"
+#include "afrl/cmasi/OperatingRegion.h"
+#include "afrl/cmasi/AbstractZone.h"
+#include "afrl/impact/AreaOfInterest.h"
+#include "afrl/impact/LineOfInterest.h"
+#include "afrl/impact/PointOfInterest.h"
 
 #include <set>
 #include <cstdint> // int64_t

--- a/src/cpp/Services/AutomationRequestValidatorService.cpp
+++ b/src/cpp/Services/AutomationRequestValidatorService.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "AutomationRequestValidatorService.h"
-
 #include "TimeUtilities.h"
 #include "UxAS_Log.h"
 #include "UxAS_TimerManager.h"
@@ -24,14 +23,9 @@
 #include "uxas/messages/task/TaskAutomationRequest.h"
 #include "uxas/messages/task/TaskAutomationResponse.h"
 #include "uxas/messages/task/UniqueAutomationResponse.h"
+
 #include "afrl/cmasi/AutomationRequest.h"
 #include "afrl/cmasi/AutomationResponse.h"
-#include "afrl/impact/ImpactAutomationRequest.h"
-#include "afrl/impact/ImpactAutomationResponse.h"
-#include "afrl/impact/PointOfInterest.h"
-#include "afrl/impact/LineOfInterest.h"
-#include "afrl/impact/AreaOfInterest.h"
-
 #include "afrl/cmasi/ServiceStatus.h"
 #include "afrl/cmasi/EntityConfiguration.h"
 #include "afrl/cmasi/EntityConfigurationDescendants.h"
@@ -40,10 +34,13 @@
 #include "afrl/cmasi/RemoveTasks.h"
 #include "afrl/cmasi/KeepInZone.h"
 #include "afrl/cmasi/KeepOutZone.h"
-
 #include "afrl/cmasi/Task.h"
 #include "afrl/cmasi/TaskDescendants.h"    
-
+#include "afrl/impact/ImpactAutomationRequest.h"
+#include "afrl/impact/ImpactAutomationResponse.h"
+#include "afrl/impact/PointOfInterest.h"
+#include "afrl/impact/LineOfInterest.h"
+#include "afrl/impact/AreaOfInterest.h"
 #include "afrl/impact/PointOfInterest.h"
 #include "afrl/impact/LineOfInterest.h"
 #include "afrl/impact/AreaOfInterest.h"

--- a/src/cpp/Services/AutomationRequestValidatorService.h
+++ b/src/cpp/Services/AutomationRequestValidatorService.h
@@ -21,10 +21,11 @@
 #include "ServiceBase.h"
 #include "CallbackTimer.h"
 
-#include "afrl/cmasi/OperatingRegion.h"
-#include "afrl/cmasi/Task.h"
 #include "uxas/messages/task/UniqueAutomationRequest.h"
 #include "uxas/messages/task/UniqueAutomationResponse.h"
+
+#include "afrl/cmasi/OperatingRegion.h"
+#include "afrl/cmasi/Task.h"
 
 #include <memory>
 #include <deque>

--- a/src/cpp/Services/BatchSummaryService.h
+++ b/src/cpp/Services/BatchSummaryService.h
@@ -14,25 +14,23 @@
  * Created on Oct 25, 2015, 3:56 PM
  */
 
-
-
 #ifndef UXAS_SERVICE_BATCH_SUMMARY_SERVICE_H
 #define UXAS_SERVICE_BATCH_SUMMARY_SERVICE_H
 
 #include "ServiceBase.h"
+#include "visilibity.h"
+
+#include "uxas/messages/route/ROUTE.h"
+#include "uxas/messages/task/TaskAutomationResponse.h"
+#include "uxas/messages/task/TaskAutomationRequest.h"
 #include "afrl/cmasi/CMASI.h"
 #include "afrl/impact/IMPACT.h"
-#include "uxas/messages/route/ROUTE.h"
-
-#include "visilibity.h"
 
 #include <memory>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <cstdint>
-#include "uxas/messages/task/TaskAutomationResponse.h"
-#include "uxas/messages/task/TaskAutomationRequest.h"
 
 namespace uxas
 {

--- a/src/cpp/Services/OsmPlannerService.cpp
+++ b/src/cpp/Services/OsmPlannerService.cpp
@@ -15,16 +15,13 @@
  *
  */
 
-
 #include "OsmPlannerService.h"
-
 #include "Position.h"   //V_POSITION_t
 #include "Waypoint.h"
 //#include "Vehicle.h"
 #include "PathInformation.h"
 #include "FileSystemUtilities.h"
 #include "Constants/UxAS_String.h"
-
 #include "Constants/Convert.h"
 
 #include "pugixml.hpp"
@@ -942,7 +939,7 @@ bool OsmPlannerService::isGetRoadPoints(const int64_t& startNodeId,const int64_t
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////        
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////    
 
-bool OsmPlannerService::isBuildRoadGraphWithOsm(const string & osmFile)
+bool OsmPlannerService::isBuildRoadGraphWithOsm(const std::string & osmFile)
 {
     bool isSuccess(true);
 
@@ -1877,8 +1874,8 @@ bool OsmPlannerService::isGetNodesOnSegment(const std::pair<int64_t, int64_t>& s
 
 void OsmPlannerService::savePythonPlotCode()
 {
-    string pythonFile = m_strSavePath + "/" + "PlotOSM_Paths.py";
-    ofstream pythonFileStream(pythonFile.c_str());
+    std::string pythonFile = m_strSavePath + "/" + "PlotOSM_Paths.py";
+    std::ofstream pythonFileStream(pythonFile.c_str());
 
     pythonFileStream << "#! /usr/bin/env python" << std::endl;
     pythonFileStream << std::endl;

--- a/src/cpp/Services/OsmPlannerService.h
+++ b/src/cpp/Services/OsmPlannerService.h
@@ -19,11 +19,8 @@
 
 #include "Position.h"
 #include "Edge.h"
-
-
 #include "VisibilityGraph.h"
 #include "FlatEarth.h"
-
 #include "ServiceBase.h"
 #include "Constants/Constants_Control.h"
 
@@ -183,7 +180,7 @@ protected:
     bool isProcessRoadPointsRequest(const std::shared_ptr<uxas::messages::route::RoadPointsRequest>& roadPointsRequest,
                                     std::shared_ptr<uxas::messages::route::RoadPointsResponse>& roadPointsResponse);
     bool isGetRoadPoints(const int64_t& startNodeId,const int64_t& endNodeId,int32_t& pathCost,std::deque<int64_t>& pathNodeIds);
-    bool isBuildRoadGraphWithOsm(const string& osmFile);
+    bool isBuildRoadGraphWithOsm(const std::string& osmFile);
     bool isFindShortestRoute(const int64_t& startNodeId, const int64_t& endNodeId,
             int32_t& pathCost, std::deque<int64_t>& pathNodes);
     bool isProcessHighwayNodes(const std::unordered_map<int64_t, bool>& nodeIdVs_isPlanningNode,

--- a/src/cpp/Services/PlanBuilderService.h
+++ b/src/cpp/Services/PlanBuilderService.h
@@ -26,13 +26,14 @@
 #include "uxas/messages/task/TaskImplementationRequest.h"
 #include "uxas/messages/task/TaskImplementationResponse.h"
 #include "uxas/messages/task/PlanningState.h"
+
 #include "afrl/cmasi/EntityState.h"
 #include "afrl/cmasi/GimbalState.h"
 #include "afrl/cmasi/GimbalAngleAction.h"
+#include "afrl/cmasi/LoiterAction.h"
 #include "afrl/impact/SpeedAltPair.h"
-#include <afrl/cmasi/LoiterAction.h>
-#include <afrl/impact/ImpactAutomationRequest.h>
-#include <afrl/impact/ImpactAutomationResponse.h>
+#include "afrl/impact/ImpactAutomationRequest.h"
+#include "afrl/impact/ImpactAutomationResponse.h"
 
 #include <cstdint> // int64_t
 #include <deque>

--- a/src/cpp/Services/RouteAggregatorService.cpp
+++ b/src/cpp/Services/RouteAggregatorService.cpp
@@ -15,12 +15,12 @@
  */
 
 #include "RouteAggregatorService.h"
-
 #include "UxAS_Log.h"
-#include "pugixml.hpp"
 #include "UnitConversions.h"
 #include "DRand.h"
 #include "Constants/UxAS_String.h"
+
+#include "pugixml.hpp"
 
 #include <map>
 

--- a/src/cpp/Services/RouteAggregatorService.h
+++ b/src/cpp/Services/RouteAggregatorService.h
@@ -20,13 +20,14 @@
 #define UXAS_SERVICE_ROUTE_AGGREGATOR_SERVICE_H
 
 #include "ServiceBase.h"
+#include "visilibity.h"
+
+#include "uxas/messages/task/UXTASK.h"
+#include "uxas/messages/route/ROUTE.h"
+
 #include "afrl/cmasi/CMASI.h"
 #include "afrl/impact/IMPACT.h"
 #include "afrl/vehicles/VEHICLES.h"
-#include "uxas/messages/route/ROUTE.h"
-#include "uxas/messages/task/UXTASK.h"
-
-#include "visilibity.h"
 
 #include <memory>
 #include <tuple>

--- a/src/cpp/Services/RoutePlannerService.cpp
+++ b/src/cpp/Services/RoutePlannerService.cpp
@@ -15,15 +15,14 @@
  */
 
 #include "RoutePlannerService.h"
-
 #include "UxAS_Log.h"
 #include "UnitConversions.h"
 #include "Constants/Convert.h"
 #include "Constants/UxAS_String.h"
 
+#include "uxas/messages/route/ROUTE.h"
 #include "afrl/cmasi/CMASI.h"
 #include "afrl/impact/IMPACT.h"
-#include "uxas/messages/route/ROUTE.h"
 
 #include "pugixml.hpp"
 

--- a/src/cpp/Services/RoutePlannerService.h
+++ b/src/cpp/Services/RoutePlannerService.h
@@ -20,11 +20,12 @@
 #define UXAS_SERVICE_ROUTE_PLANNER_SERVICE_H
 
 #include "ServiceBase.h"
-#include "afrl/cmasi/CMASI.h"
+#include "visilibity.h"
+
 #include "uxas/messages/route/ROUTE.h"
+#include "afrl/cmasi/CMASI.h"
 #include "afrl/impact/IMPACT.h"
 #include "afrl/vehicles/VEHICLES.h"
-#include "visilibity.h"
 
 #include <unordered_map>
 #include <unordered_set>

--- a/src/cpp/Services/RoutePlannerVisibilityService.cpp
+++ b/src/cpp/Services/RoutePlannerVisibilityService.cpp
@@ -14,25 +14,19 @@
  * Created on February 19, 2015, 4:47 PM
  *
  */
-
-
 #include "RoutePlannerVisibilityService.h"
-
 #include "Position.h"   //V_POSITION_t
 #include "Waypoint.h"
 #include "TrajectoryParameters.h"
 #include "PathInformation.h"
-
 #include "UnitConversions.h"
 #include "Constants/UxAS_String.h"
 
 #include "afrl/cmasi/KeepInZone.h"
 #include "afrl/cmasi/KeepOutZone.h"
-
 #include "afrl/cmasi/Circle.h"
 #include "afrl/cmasi/Polygon.h"
 #include "afrl/cmasi/Rectangle.h"
-
 #include "afrl/cmasi/EntityConfiguration.h"
 #include "afrl/cmasi/EntityConfigurationDescendants.h"
 #include "afrl/cmasi/EntityState.h"
@@ -44,11 +38,7 @@
 #include <chrono>       // time functions
 
 //TODO:: read in a open street map and calculate it's visibility graph
-
-
-
 #define STRING_COMPONENT_NAME "RoutePlannerVisibility"
-
 #define STRING_XML_COMPONENT "Component"
 #define STRING_XML_TYPE "Type"
 #define STRING_XML_COMPONENT_TYPE "RoutePlannerVisibility"
@@ -58,13 +48,12 @@
 #define STRING_XML_IS_ROUTE_AGGREGATOR "isRoutAggregator"
 #define STRING_XML_OSM_FILE_NAME "OsmFileName"
 #define STRING_XML_MINIMUM_WAYPOINT_SEPARATION_M "MinimumWaypointSeparation_m"
-
-
 #define COUT_INFO_MSG(MESSAGE) std::cout << "<>RoutePlannerVisibility::" << MESSAGE << std::endl;std::cout.flush();
 #define COUT_FILE_LINE_MSG(MESSAGE) std::cout << "<>RoutePlannerVisibility.:: " << __FILE__ << ":" << __LINE__ << ":" << MESSAGE << std::endl;std::cout.flush();
 #define CERR_FILE_LINE_MSG(MESSAGE) std::cerr << "<>RoutePlannerVisibility.:: " << __FILE__ << ":" << __LINE__ << ":" << MESSAGE << std::endl;std::cerr.flush();
-
 #define CIRCLE_BOUNDARY_INCREMENT (n_Const::c_Convert::dPiO10())
+
+using namespace std;
 
 namespace uxas
 {

--- a/src/cpp/Services/SendMessagesService.cpp
+++ b/src/cpp/Services/SendMessagesService.cpp
@@ -8,20 +8,20 @@
 // ===============================================================================
 
 #include "SendMessagesService.h"
+#include "TimeUtilities.h"
+#include "SendMessagesService.h"
+#include "Constants/Constant_Strings.h"
+#include "UxAS_ConfigurationManager.h"
+#include "UxAS_Time.h"
 
-#include "avtas/lmcp/LmcpXMLReader.h"
 #include "uxas/messages/uxnative/StartupComplete.h"
 #include "uxas/messages/route/GraphRegion.h"
 #ifdef AFRL_INTERNAL_ENABLED
 #include "uxas/project/isolate/UgsManagementTask.h"
 #endif
 
-#include "TimeUtilities.h"
-#include "SendMessagesService.h"
-#include "Constants/Constant_Strings.h"
+#include "avtas/lmcp/LmcpXMLReader.h"
 
-#include "UxAS_ConfigurationManager.h"
-#include "UxAS_Time.h"
 
 #include <sstream>
 #include <iostream>

--- a/src/cpp/Services/SensorManagerService.cpp
+++ b/src/cpp/Services/SensorManagerService.cpp
@@ -16,17 +16,18 @@
 
 
 #include "SensorManagerService.h"
+#include "Constants/Convert.h"
+
+#include "uxas/messages/task/SensorFootprintResponse.h"
+#include "uxas/messages/task/SensorFootprint.h"
 
 #include "afrl/cmasi/EntityConfiguration.h"
 #include "afrl/cmasi/EntityConfigurationDescendants.h"
 #include "afrl/cmasi/GimbalConfiguration.h"
 #include "afrl/cmasi/CameraConfiguration.h"
 #include "afrl/cmasi/RemoveTasks.h"
-#include "uxas/messages/task/SensorFootprintResponse.h"
-#include "uxas/messages/task/SensorFootprint.h"
 
 #include "pugixml.hpp"
-#include "Constants/Convert.h"
 
 #include <sstream>      //std::stringstream
 #include <iostream>     // std::cout, cerr, etc

--- a/src/cpp/Services/SensorManagerService.h
+++ b/src/cpp/Services/SensorManagerService.h
@@ -21,9 +21,10 @@
 
 #include "ServiceBase.h"
 
-#include "afrl/cmasi/EntityConfiguration.h"
 #include "uxas/messages/task/SensorFootprintRequests.h"
 #include "uxas/messages/task/SensorFootprint.h"
+
+#include "afrl/cmasi/EntityConfiguration.h"
 
 #include <set>
 #include <cstdint> // int64_t

--- a/src/cpp/Services/ServiceManager.cpp
+++ b/src/cpp/Services/ServiceManager.cpp
@@ -9,23 +9,18 @@
 
 #include "ServiceManager.h"
 #include "LmcpObjectNetworkBridgeManager.h"
-
 #define INCLUDE_SERVICE_HEADERS //this switches 00_ServiceList.h to load the service headers
 #include "00_ServiceList.h"
+#include "UxAS_ConfigurationManager.h"
+#include "Constants/UxAS_String.h"
+#include "UxAS_Log.h"
+#include "stdUniquePtr.h"
+#include "Constants/Constant_Strings.h"
+#include "FileSystemUtilities.h"
 
 #include "uxas/messages/uxnative/CreateNewService.h"
 #include "uxas/messages/uxnative/KillService.h"
 #include "uxas/messages/uxnative/StartupComplete.h"
-
-#include "UxAS_ConfigurationManager.h"
-#include "Constants/UxAS_String.h"
-#include "UxAS_Log.h"
-
-#include "stdUniquePtr.h"
-
-#include "Constants/Constant_Strings.h"
-
-#include "FileSystemUtilities.h"
 
 #if (defined(__APPLE__) && defined(__MACH__))
 #define OSX

--- a/src/cpp/Services/SimpleWaypointPlanManagerService.cpp
+++ b/src/cpp/Services/SimpleWaypointPlanManagerService.cpp
@@ -17,12 +17,12 @@
 
 
 #include "SimpleWaypointPlanManagerService.h"
+#include "UnitConversions.h"
 
 #include "afrl/cmasi/AutomationResponse.h"
 #include "afrl/cmasi/AirVehicleConfiguration.h"
 #include "afrl/vehicles/SurfaceVehicleConfiguration.h"
 
-#include "UnitConversions.h"
 
 #define STRING_XML_VEHICLE_ID "VehicleID"
 

--- a/src/cpp/Services/StatusReportService.h
+++ b/src/cpp/Services/StatusReportService.h
@@ -17,11 +17,13 @@
 #ifndef UXAS_STATUSREPORTSERVICE_H
 #define UXAS_STATUSREPORTSERVICE_H
 
-#include <mutex>
-#include <unordered_set>
 #include "ServiceBase.h"
 #include "CallbackTimer.h"
+
 #include "uxas/messages/uxnative/OnboardStatusReport.h"
+
+#include <mutex>
+#include <unordered_set>
 
 namespace uxas
 {

--- a/src/cpp/Services/SteeringService.cpp
+++ b/src/cpp/Services/SteeringService.cpp
@@ -8,6 +8,17 @@
 // ===============================================================================
 
 #include "SteeringService.h"
+#include "Constants/Convert.h"
+#include "Constants/UxAS_String.h"
+#include "FlatEarth.h"
+#include "UxAS_Log.h"
+#include "UxAS_Time.h"
+#include "stdUniquePtr.h"
+
+#include "uxas/messages/uxnative/SafeHeadingAction.h"
+#include "uxas/messages/task/UniqueAutomationRequest.h"
+#include "uxas/messages/task/UniqueAutomationResponse.h"
+#include "uxas/messages/uxnative/SpeedOverrideAction.h"
 
 #include "afrl/cmasi/AirVehicleConfiguration.h"
 #include "afrl/cmasi/AirVehicleConfigurationDescendants.h"
@@ -21,22 +32,9 @@
 #include "afrl/cmasi/SpeedType.h"
 #include "afrl/cmasi/VehicleAction.h"
 #include "afrl/cmasi/VehicleActionCommand.h"
-#include "uxas/messages/uxnative/SafeHeadingAction.h"
-#include "uxas/messages/task/UniqueAutomationRequest.h"
-#include "uxas/messages/task/UniqueAutomationResponse.h"
-#include "uxas/messages/uxnative/SpeedOverrideAction.h"
-
-#include "Constants/Convert.h"
-#include "Constants/UxAS_String.h"
-#include "FlatEarth.h"
-#include "UxAS_Log.h"
-#include "UxAS_Time.h"
-
-#include "stdUniquePtr.h"
 
 #include <algorithm>
 #include <vector>
-
 #include <cassert>
 #include <cmath>
 

--- a/src/cpp/Services/SteeringService.h
+++ b/src/cpp/Services/SteeringService.h
@@ -11,10 +11,10 @@
 #define UXAS_STEERING_SERVICE_H
 
 #include "ServiceBase.h"
-
-#include "afrl/cmasi/Waypoint.h"
 #include "Constants/Constant_Strings.h"
 #include "visilibity.h"
+
+#include "afrl/cmasi/Waypoint.h"
 
 #include <memory>
 #include <unordered_map>

--- a/src/cpp/Services/Test_SimulationTime.cpp
+++ b/src/cpp/Services/Test_SimulationTime.cpp
@@ -8,11 +8,10 @@
 // ===============================================================================
 
 #include "Test_SimulationTime.h"
+#include "UxAS_Time.h"
 
 #include "afrl/cmasi/EntityState.h"
 #include "afrl/cmasi/EntityStateDescendants.h"
-
-#include "UxAS_Time.h"
 
 //#define STRING_XML_NUMBER_PLANS_MAX "NumberPlansMax"
 

--- a/src/cpp/Services/WaypointPlanManagerService.cpp
+++ b/src/cpp/Services/WaypointPlanManagerService.cpp
@@ -17,17 +17,16 @@
 
 
 #include "WaypointPlanManagerService.h"
-
 #include "UnitConversions.h"
 #include "UxAS_TimerManager.h"
 
+#include "uxas/messages/uxnative/IncrementWaypoint.h"
+
 #include "afrl/cmasi/AirVehicleState.h"
 #include "afrl/cmasi/AirVehicleStateDescendants.h"
-
 #include "afrl/cmasi/AutomationResponse.h"
 #include "afrl/cmasi/GimbalAngleAction.h"
 #include "afrl/cmasi/LoiterAction.h"
-#include "uxas/messages/uxnative/IncrementWaypoint.h"
 
 #include "pugixml.hpp"
 

--- a/src/cpp/Tasks/AngledAreaSearchTaskService.cpp
+++ b/src/cpp/Tasks/AngledAreaSearchTaskService.cpp
@@ -14,16 +14,12 @@
  * Created on October 19, 2015, 6:17 PM
  */
 
-
 #include "AngledAreaSearchTaskService.h"
-
 #include "Position.h"
 #include "FileSystemUtilities.h"
 #include "Polygon.h"
+#include "Constants/Convert.h"
 
-#include "afrl/cmasi/Circle.h"
-#include "afrl/cmasi/Polygon.h"
-#include "afrl/cmasi/Rectangle.h"
 #include "uxas/messages/task/SensorFootprintResponse.h"
 #include "uxas/messages/task/FootprintRequest.h"
 #include "uxas/messages/task/SensorFootprintRequests.h"
@@ -31,15 +27,16 @@
 #include "uxas/messages/route/ROUTE.h"
 #include "uxas/messages/route/RouteConstraints.h"
 
-#include "Constants/Convert.h"
+#include "afrl/cmasi/Circle.h"
+#include "afrl/cmasi/Polygon.h"
+#include "afrl/cmasi/Rectangle.h"
+#include "afrl/cmasi/ServiceStatus.h"
 
 #include <sstream>      //std::stringstream
 #include <iomanip>  //setfill
-#include "afrl/cmasi/ServiceStatus.h"
 
 #define STRING_XML_LANE_SPACING_MIN "SearchLaneWidthMin_m"
 #define STRING_XML_LANE_SPACING_MAX "SearchLaneWidthMax_m"
-
 
 namespace uxas
 {

--- a/src/cpp/Tasks/AssignmentCoordinatorTaskService.cpp
+++ b/src/cpp/Tasks/AssignmentCoordinatorTaskService.cpp
@@ -19,14 +19,13 @@
 
 // include header for this service
 #include "AssignmentCoordinatorTaskService.h"
-
 #include "UxAS_Time.h"
 
+#include "uxas/messages/task/TaskAutomationRequest.h"
+#include "uxas/messages/task/TaskAutomationResponse.h"
 
 #include "afrl/cmasi/AirVehicleState.h"
 #include "afrl/cmasi/AirVehicleStateDescendants.h"
-#include "uxas/messages/task/TaskAutomationRequest.h"
-#include "uxas/messages/task/TaskAutomationResponse.h"
 
 #include <iostream>     // std::cout, cerr, etc
 

--- a/src/cpp/Tasks/BlockadeTaskService.cpp
+++ b/src/cpp/Tasks/BlockadeTaskService.cpp
@@ -14,12 +14,17 @@
  * Created on February 26, 2016, 6:17 PM
  */
 
-
 #include "BlockadeTaskService.h"
-
 #include "Position.h"
 #include "UnitConversions.h"
+#include "Constants/Convert.h"
+#include "DpssDataTypes.h"
 
+#include "uxas/messages/task/TaskImplementationResponse.h"
+#include "uxas/messages/task/TaskOption.h"
+#include "uxas/messages/route/RouteRequest.h"
+#include "uxas/messages/route/RouteResponse.h"
+#include "uxas/messages/route/RouteConstraints.h"
 #include "avtas/lmcp/LmcpXMLReader.h"
 #include "afrl/cmasi/VehicleActionCommand.h"
 #include "afrl/cmasi/GimbalStareAction.h"
@@ -29,19 +34,11 @@
 #include "afrl/cmasi/AirVehicleConfiguration.h"
 #include "afrl/vehicles/GroundVehicleConfiguration.h"
 #include "afrl/vehicles/SurfaceVehicleConfiguration.h"
-#include "uxas/messages/task/TaskImplementationResponse.h"
-#include "uxas/messages/task/TaskOption.h"
-#include "uxas/messages/route/RouteRequest.h"
-#include "uxas/messages/route/RouteResponse.h"
-#include "uxas/messages/route/RouteConstraints.h"
 
 #include "pugixml.hpp"
-#include "Constants/Convert.h"
-#include "DpssDataTypes.h"
 
 #include <sstream>      //std::stringstream
 #include <iostream>     // std::cout, cerr, etc
-
 
 #define STRING_XML_ENTITY_STATES "EntityStates" //TODO:: define this in some global place
 

--- a/src/cpp/Tasks/BlockadeTaskService.h
+++ b/src/cpp/Tasks/BlockadeTaskService.h
@@ -20,14 +20,15 @@
 #include "TaskServiceBase.h"
 #include "ServiceBase.h"
 
-#include "afrl/cmasi/AutomationRequest.h"
-#include "afrl/impact/BlockadeTask.h"
-#include "afrl/cmasi/EntityConfiguration.h"
-#include "afrl/cmasi/EntityState.h"
-#include "afrl/cmasi/VehicleActionCommand.h"
 #include "uxas/messages/task/TaskPlanOptions.h"
 #include "uxas/messages/task/TaskImplementationRequest.h"
 #include "uxas/messages/route/RoutePlan.h"
+
+#include "afrl/cmasi/AutomationRequest.h"
+#include "afrl/cmasi/EntityConfiguration.h"
+#include "afrl/cmasi/EntityState.h"
+#include "afrl/cmasi/VehicleActionCommand.h"
+#include "afrl/impact/BlockadeTask.h"
 
 #include <cstdint> // int64_t
 #include <unordered_set>

--- a/src/cpp/Tasks/CmasiAreaSearchTaskService.cpp
+++ b/src/cpp/Tasks/CmasiAreaSearchTaskService.cpp
@@ -16,17 +16,11 @@
 
 
 #include "CmasiAreaSearchTaskService.h"
-
 #include "Position.h"
 #include "FileSystemUtilities.h"
 #include "Polygon.h"
+#include "Constants/Convert.h"
 
-#include "afrl/cmasi/Circle.h"
-#include "afrl/cmasi/Polygon.h"
-#include "afrl/cmasi/Rectangle.h"
-#include "afrl/cmasi/VehicleActionCommand.h"
-#include "afrl/cmasi/GimbalAngleAction.h"
-#include "afrl/cmasi/GimbalConfiguration.h"
 #include "uxas/messages/task/SensorFootprintResponse.h"
 #include "uxas/messages/task/FootprintRequest.h"
 #include "uxas/messages/task/SensorFootprintRequests.h"
@@ -36,8 +30,14 @@
 #include "uxas/messages/route/RouteConstraints.h"
 #include "uxas/messages/uxnative/VideoRecord.h"
 
+#include "afrl/cmasi/Circle.h"
+#include "afrl/cmasi/Polygon.h"
+#include "afrl/cmasi/Rectangle.h"
+#include "afrl/cmasi/VehicleActionCommand.h"
+#include "afrl/cmasi/GimbalAngleAction.h"
+#include "afrl/cmasi/GimbalConfiguration.h"
+
 #include "pugixml.hpp"
-#include "Constants/Convert.h"
 
 #include <sstream>      //std::stringstream
 #include <iostream>     // std::cout, cerr, etc

--- a/src/cpp/Tasks/CmasiLineSearchTaskService.cpp
+++ b/src/cpp/Tasks/CmasiLineSearchTaskService.cpp
@@ -20,18 +20,19 @@
 #include "Position.h"
 #include "UnitConversions.h"
 #include "FileSystemUtilities.h"
+#include "Constants/Convert.h"
 
-#include "afrl/cmasi/VehicleActionCommand.h"
-#include "afrl/cmasi/GimbalStareAction.h"
-#include "afrl/cmasi/GimbalConfiguration.h"
 #include "uxas/messages/task/TaskImplementationResponse.h"
 #include "uxas/messages/task/TaskOption.h"
 #include "uxas/messages/route/RouteRequest.h"
 #include "uxas/messages/route/RouteConstraints.h"
 #include "uxas/messages/uxnative/VideoRecord.h"
 
+#include "afrl/cmasi/VehicleActionCommand.h"
+#include "afrl/cmasi/GimbalStareAction.h"
+#include "afrl/cmasi/GimbalConfiguration.h"
+
 #include "pugixml.hpp"
-#include "Constants/Convert.h"
 
 #include <sstream>      //std::stringstream
 #include <iostream>     // std::cout, cerr, etc
@@ -42,6 +43,7 @@
 #define COUT_FILE_LINE_MSG(MESSAGE) std::cout << "CMLS-CMLS-CMLS-CMLS:: CmasiLineSearch:" << __FILE__ << ":" << __LINE__ << ":" << MESSAGE << std::endl;std::cout.flush();
 #define CERR_FILE_LINE_MSG(MESSAGE) std::cerr << "CMLS-CMLS-CMLS-CMLS:: CmasiLineSearch:" << __FILE__ << ":" << __LINE__ << ":" << MESSAGE << std::endl;std::cerr.flush();
 
+using namespace Dpss_Data_n;
 
 namespace uxas
 {

--- a/src/cpp/Tasks/CmasiPointSearchTaskService.cpp
+++ b/src/cpp/Tasks/CmasiPointSearchTaskService.cpp
@@ -16,25 +16,25 @@
 
 
 #include "CmasiPointSearchTaskService.h"
-
 #include "Position.h"
 #include "UnitConversions.h"
+#include "Constants/Convert.h"
 
-#include "afrl/cmasi/VehicleActionCommand.h"
-#include "afrl/cmasi/GimbalStareAction.h"
-#include "afrl/cmasi/GimbalConfiguration.h"
 #include "uxas/messages/task/TaskImplementationResponse.h"
 #include "uxas/messages/task/TaskOption.h"
 #include "uxas/messages/route/RouteRequest.h"
 #include "uxas/messages/route/RouteResponse.h"
 #include "uxas/messages/route/RouteConstraints.h"
 
+#include "afrl/cmasi/VehicleActionCommand.h"
+#include "afrl/cmasi/GimbalStareAction.h"
+#include "afrl/cmasi/GimbalConfiguration.h"
+
 #ifdef AFRL_INTERNAL_ENABLED
 #include "afrl/famus/PointSearchTask.h"
 #endif
 
 #include "pugixml.hpp"
-#include "Constants/Convert.h"
 
 #include <sstream>      //std::stringstream
 #include <iostream>     // std::cout, cerr, etc

--- a/src/cpp/Tasks/CmasiPointSearchTaskService.h
+++ b/src/cpp/Tasks/CmasiPointSearchTaskService.h
@@ -17,16 +17,16 @@
 #ifndef UXAS_SERVICE_TASK_CMASI_POINT_SEARCH_TASK_SERVICE_H
 #define UXAS_SERVICE_TASK_CMASI_POINT_SEARCH_TASK_SERVICE_H
 
-
 #include "TaskServiceBase.h"
+
+#include "uxas/messages/task/TaskPlanOptions.h"
+#include "uxas/messages/task/TaskImplementationRequest.h"
+#include "uxas/messages/route/RoutePlan.h"
 
 #include "afrl/cmasi/AutomationRequest.h"
 #include "afrl/cmasi/PointSearchTask.h"
 #include "afrl/cmasi/EntityConfiguration.h"
 #include "afrl/cmasi/EntityState.h"
-#include "uxas/messages/task/TaskPlanOptions.h"
-#include "uxas/messages/task/TaskImplementationRequest.h"
-#include "uxas/messages/route/RoutePlan.h"
 
 #include <cstdint> // int64_t
 #include <unordered_set>

--- a/src/cpp/Tasks/CommRelayTaskService.cpp
+++ b/src/cpp/Tasks/CommRelayTaskService.cpp
@@ -14,11 +14,15 @@
  * Created on March 7, 2016, 6:17 PM
  */
 
-
 #include "CommRelayTaskService.h"
-
 #include "Position.h"
 #include "UnitConversions.h"
+#include "Constants/Convert.h"
+#include "DpssDataTypes.h"
+#include "TimeUtilities.h"
+
+#include "uxas/messages/task/TaskImplementationResponse.h"
+#include "uxas/messages/task/TaskOption.h"
 
 #include "avtas/lmcp/LmcpXMLReader.h"
 #include "afrl/cmasi/VehicleActionCommand.h"
@@ -31,17 +35,8 @@
 #include "afrl/vehicles/SurfaceVehicleConfiguration.h"
 #include "afrl/impact/RadioTowerConfiguration.h"
 #include "afrl/impact/RadioTowerState.h"
-#include "uxas/messages/task/TaskImplementationResponse.h"
-#include "uxas/messages/task/TaskOption.h"
-
-
-#include "Constants/Convert.h"
-#include "DpssDataTypes.h"
-#include "TimeUtilities.h"
 
 #include <sstream>      //std::stringstream
-
-
 
 namespace uxas
 {

--- a/src/cpp/Tasks/CommRelayTaskService.h
+++ b/src/cpp/Tasks/CommRelayTaskService.h
@@ -19,20 +19,21 @@
 
 #include "TaskServiceBase.h"
 #include "ServiceBase.h"
+#include "DynamicTaskServiceBase.h"
 
-#include "afrl/cmasi/AutomationRequest.h"
-#include "afrl/impact/CommRelayTask.h"
-#include "afrl/cmasi/EntityConfiguration.h"
-#include "afrl/cmasi/EntityState.h"
-#include "afrl/cmasi/VehicleActionCommand.h"
 #include "uxas/messages/task/TaskPlanOptions.h"
 #include "uxas/messages/task/TaskImplementationRequest.h"
 #include "uxas/messages/route/RoutePlan.h"
 
+#include "afrl/impact/CommRelayTask.h"
+#include "afrl/cmasi/AutomationRequest.h"
+#include "afrl/cmasi/EntityConfiguration.h"
+#include "afrl/cmasi/EntityState.h"
+#include "afrl/cmasi/VehicleActionCommand.h"
+
 #include <cstdint> // int64_t
 #include <unordered_set>
 #include <unordered_map>
-#include "DynamicTaskServiceBase.h"
 
 namespace uxas
 {

--- a/src/cpp/Tasks/CordonTaskService.cpp
+++ b/src/cpp/Tasks/CordonTaskService.cpp
@@ -16,9 +16,10 @@
 
 
 #include "CordonTaskService.h"
-
 #include "Position.h"
 #include "FileSystemUtilities.h"
+#include "Constants/Convert.h"
+#include "Permute.h"
 
 #include "uxas/messages/task/TaskImplementationResponse.h"
 #include "uxas/messages/task/TaskOption.h"
@@ -28,8 +29,6 @@
 #include "uxas/messages/route/EgressRouteResponse.h"
 
 #include "pugixml.hpp"
-#include "Constants/Convert.h"
-#include "Permute.h"
 
 #include <sstream>      //std::stringstream
 #include <iostream>     // std::cout, cerr, etc

--- a/src/cpp/Tasks/DynamicTaskServiceBase.h
+++ b/src/cpp/Tasks/DynamicTaskServiceBase.h
@@ -20,15 +20,16 @@
 #include "TimeUtilities.h"
 #include "visilibity.h"
 #include "UnitConversions.h"
+#include "BatchSummaryService.h"
+
 #include "afrl/cmasi/GimbalStareAction.h"
 #include "afrl/cmasi/LoiterAction.h"
-#include "afrl/vehicles/GroundVehicleState.h"
 #include "afrl/cmasi/GimbalConfiguration.h"
-#include "afrl/vehicles/GroundVehicleConfiguration.h"
-#include "afrl/vehicles/SurfaceVehicleConfiguration.h"
 #include "afrl/cmasi/AirVehicleConfiguration.h"
 #include "afrl/cmasi/OperatingRegion.h"
-#include "BatchSummaryService.h"
+#include "afrl/vehicles/GroundVehicleState.h"
+#include "afrl/vehicles/GroundVehicleConfiguration.h"
+#include "afrl/vehicles/SurfaceVehicleConfiguration.h"
 
 namespace uxas
 {

--- a/src/cpp/Tasks/EscortTaskService.cpp
+++ b/src/cpp/Tasks/EscortTaskService.cpp
@@ -14,11 +14,14 @@
  * Created on March 7, 2016, 3:03 PM
  */
 
-
 #include "EscortTaskService.h"
-
 #include "Position.h"
 #include "UnitConversions.h"
+#include "Constants/Convert.h"
+#include "DpssDataTypes.h"
+#include "TimeUtilities.h"
+
+#include "uxas/messages/task/TaskOption.h"
 
 #include "avtas/lmcp/LmcpXMLReader.h"
 #include "afrl/cmasi/VehicleActionCommand.h"
@@ -32,17 +35,9 @@
 #include "afrl/vehicles/SurfaceVehicleConfiguration.h"
 #include "afrl/vehicles/GroundVehicleState.h"
 #include "afrl/vehicles/SurfaceVehicleState.h"
-#include "uxas/messages/task/TaskOption.h"
-
-
-#include "Constants/Convert.h"
-#include "DpssDataTypes.h"
-#include "TimeUtilities.h"
 
 #include <sstream>      //std::stringstream
 #include <iostream>     // std::cout, cerr, etc
-
-
 
 namespace uxas
 {

--- a/src/cpp/Tasks/EscortTaskService.h
+++ b/src/cpp/Tasks/EscortTaskService.h
@@ -19,19 +19,20 @@
 
 #include "TaskServiceBase.h"
 #include "ServiceBase.h"
+#include "DynamicTaskServiceBase.h"
+
+#include "uxas/messages/task/TaskPlanOptions.h"
+#include "uxas/messages/task/TaskImplementationRequest.h"
+#include "uxas/messages/route/RoutePlan.h"
 
 #include "afrl/cmasi/AutomationRequest.h"
 #include "afrl/impact/EscortTask.h"
 #include "afrl/cmasi/EntityConfiguration.h"
 #include "afrl/cmasi/EntityState.h"
-#include "uxas/messages/task/TaskPlanOptions.h"
-#include "uxas/messages/task/TaskImplementationRequest.h"
-#include "uxas/messages/route/RoutePlan.h"
 
 #include <cstdint> // int64_t
 #include <unordered_set>
 #include <unordered_map>
-#include "DynamicTaskServiceBase.h"
 
 namespace uxas
 {

--- a/src/cpp/Tasks/ImpactLineSearchTaskService.cpp
+++ b/src/cpp/Tasks/ImpactLineSearchTaskService.cpp
@@ -16,23 +16,23 @@
 
 
 #include "ImpactLineSearchTaskService.h"
-
 #include "Position.h"
 #include "UnitConversions.h"
 #include "FileSystemUtilities.h"
+#include "Constants/Convert.h"
 
-#include "afrl/cmasi/VehicleActionCommand.h"
-#include "afrl/cmasi/GimbalStareAction.h"
-#include "afrl/cmasi/GimbalConfiguration.h"
-#include "afrl/impact/ImpactLineSearchTask.h"
 #include "uxas/messages/task/TaskImplementationResponse.h"
 #include "uxas/messages/task/TaskOption.h"
 #include "uxas/messages/route/RouteRequest.h"
 #include "uxas/messages/route/RouteConstraints.h"
 #include "uxas/messages/uxnative/VideoRecord.h"
 
+#include "afrl/cmasi/VehicleActionCommand.h"
+#include "afrl/cmasi/GimbalStareAction.h"
+#include "afrl/cmasi/GimbalConfiguration.h"
+#include "afrl/impact/ImpactLineSearchTask.h"
+
 #include "pugixml.hpp"
-#include "Constants/Convert.h"
 
 #include <sstream>      //std::stringstream
 #include <iostream>     // std::cout, cerr, etc
@@ -43,6 +43,7 @@
 #define COUT_FILE_LINE_MSG(MESSAGE) std::cout << "IMPCT_LS-IMPCT_LS-IMPCT_LS-IMPCT_LS:: ImpactLineSearch:" << __FILE__ << ":" << __LINE__ << ":" << MESSAGE << std::endl;std::cout.flush();
 #define CERR_FILE_LINE_MSG(MESSAGE) std::cerr << "IMPCT_LS-IMPCT_LS-IMPCT_LS-IMPCT_LS:: ImpactLineSearch:" << __FILE__ << ":" << __LINE__ << ":" << MESSAGE << std::endl;std::cerr.flush();
 
+using namespace Dpss_Data_n;
 
 namespace uxas
 {

--- a/src/cpp/Tasks/ImpactPointSearchTaskService.cpp
+++ b/src/cpp/Tasks/ImpactPointSearchTaskService.cpp
@@ -14,28 +14,26 @@
  * Created on February 12, 2015, 6:17 PM
  */
 
-
 #include "ImpactPointSearchTaskService.h"
-
 #include "Position.h"
 #include "UnitConversions.h"
+#include "Constants/Convert.h"
+#include "BatchSummaryService.h"
 
-#include "afrl/cmasi/VehicleActionCommand.h"
-#include "afrl/cmasi/GimbalStareAction.h"
 #include "uxas/messages/task/TaskOption.h"
 #include "uxas/messages/route/RouteRequest.h"
 #include "uxas/messages/route/RouteResponse.h"
 #include "uxas/messages/route/RouteConstraints.h"
 
+#include "afrl/cmasi/VehicleActionCommand.h"
+#include "afrl/cmasi/GimbalStareAction.h"
+#include "afrl/cmasi/GimbalConfiguration.h"
+#include "avtas/lmcp/LmcpXMLReader.h"
+
 #include "pugixml.hpp"
-#include "Constants/Convert.h"
 
 #include <sstream>      //std::stringstream
 #include <iostream>     // std::cout, cerr, etc
-#include <afrl/cmasi/GimbalConfiguration.h>
-#include <avtas/lmcp/LmcpXMLReader.h>
-#include <BatchSummaryService.h>
-
 
 #define COUT_FILE_LINE_MSG(MESSAGE) std::cout << "IMPCT_PS-IMPCT_PS-IMPCT_PS-IMPCT_PS:: ImpactPointSearch:" << __FILE__ << ":" << __LINE__ << ":" << MESSAGE << std::endl;std::cout.flush();
 #define CERR_FILE_LINE_MSG(MESSAGE) std::cerr << "IMPCT_PS-IMPCT_PS-IMPCT_PS-IMPCT_PS:: ImpactPointSearch:" << __FILE__ << ":" << __LINE__ << ":" << MESSAGE << std::endl;std::cerr.flush();

--- a/src/cpp/Tasks/ImpactPointSearchTaskService.h
+++ b/src/cpp/Tasks/ImpactPointSearchTaskService.h
@@ -19,17 +19,18 @@
 
 #include "TaskServiceBase.h"
 #include "ServiceBase.h"
+#include "visilibity.h"
 
-#include "afrl/cmasi/AutomationRequest.h"
-#include "afrl/impact/ImpactPointSearchTask.h"
-#include "afrl/cmasi/EntityConfiguration.h"
-#include "afrl/cmasi/EntityState.h"
 #include "uxas/messages/task/TaskPlanOptions.h"
 #include "uxas/messages/task/TaskImplementationRequest.h"
 #include "uxas/messages/route/RoutePlan.h"
+
+#include "afrl/cmasi/AutomationRequest.h"
+#include "afrl/cmasi/EntityConfiguration.h"
+#include "afrl/cmasi/EntityState.h"
 #include "afrl/cmasi/KeepOutZone.h"
-#include <afrl/vehicles/SurfaceVehicleState.h>
-#include "visilibity.h"
+#include "afrl/impact/ImpactPointSearchTask.h"
+#include "afrl/vehicles/SurfaceVehicleState.h"
 
 #include <cstdint> // int64_t
 #include <unordered_set>

--- a/src/cpp/Tasks/LoiterTaskService.cpp
+++ b/src/cpp/Tasks/LoiterTaskService.cpp
@@ -16,20 +16,20 @@
 
 
 #include "LoiterTaskService.h"
-
 #include "Position.h"
 #include "FileSystemUtilities.h"
 #include "Polygon.h"
 
-#include "afrl/cmasi/Circle.h"
 #include "uxas/messages/task/SensorFootprintResponse.h"
 #include "uxas/messages/task/TaskImplementationResponse.h"
 #include "uxas/messages/task/TaskOption.h"
 #include "uxas/messages/route/ROUTE.h"
 
+#include "afrl/cmasi/Circle.h"
+#include "afrl/cmasi/LoiterAction.h"
+
 #include <sstream>      //std::stringstream
 #include <iomanip>  //setfill
-#include "afrl/cmasi/LoiterAction.h"
 
 
 

--- a/src/cpp/Tasks/LoiterTaskService.h
+++ b/src/cpp/Tasks/LoiterTaskService.h
@@ -18,14 +18,15 @@
 #define UXAS_SERVICE_TASK_LOITER_TASK_SERVICE_H
 
 #include "UnitConversions.h"
+#include "TaskServiceBase.h"
+
+#include "uxas/messages/route/RouteRequest.h"
 
 #include "afrl/cmasi/MustFlyTask.h"
-#include "uxas/messages/route/RouteRequest.h"
+#include "afrl/cmasi/LoiterTask.h"
 
 #include <cstdint> // int64_t
 #include <unordered_map>
-#include "TaskServiceBase.h"
-#include "afrl/cmasi/LoiterTask.h"
 
 namespace uxas
 {

--- a/src/cpp/Tasks/MultiVehicleWatchTaskService.cpp
+++ b/src/cpp/Tasks/MultiVehicleWatchTaskService.cpp
@@ -16,9 +16,16 @@
 
 
 #include "MultiVehicleWatchTaskService.h"
-
 #include "Position.h"
 #include "UnitConversions.h"
+#include "Constants/Convert.h"
+#include "DpssDataTypes.h"
+
+#include "uxas/messages/task/TaskImplementationResponse.h"
+#include "uxas/messages/task/TaskOption.h"
+#include "uxas/messages/route/RouteRequest.h"
+#include "uxas/messages/route/RouteResponse.h"
+#include "uxas/messages/route/RouteConstraints.h"
 
 #include "avtas/lmcp/LmcpXMLReader.h"
 #include "afrl/cmasi/VehicleActionCommand.h"
@@ -29,15 +36,8 @@
 #include "afrl/cmasi/AirVehicleConfiguration.h"
 #include "afrl/vehicles/GroundVehicleConfiguration.h"
 #include "afrl/vehicles/SurfaceVehicleConfiguration.h"
-#include "uxas/messages/task/TaskImplementationResponse.h"
-#include "uxas/messages/task/TaskOption.h"
-#include "uxas/messages/route/RouteRequest.h"
-#include "uxas/messages/route/RouteResponse.h"
-#include "uxas/messages/route/RouteConstraints.h"
 
 #include "pugixml.hpp"
-#include "Constants/Convert.h"
-#include "DpssDataTypes.h"
 
 #include <sstream>      //std::stringstream
 #include <iostream>     // std::cout, cerr, etc

--- a/src/cpp/Tasks/MustFlyTaskService.cpp
+++ b/src/cpp/Tasks/MustFlyTaskService.cpp
@@ -16,16 +16,16 @@
 
 
 #include "MustFlyTaskService.h"
-
 #include "Position.h"
 #include "FileSystemUtilities.h"
 #include "Polygon.h"
 #include "FlatEarth.h"
 
-#include "afrl/cmasi/Circle.h"
 #include "uxas/messages/task/SensorFootprintResponse.h"
 #include "uxas/messages/task/TaskOption.h"
 #include "uxas/messages/route/ROUTE.h"
+
+#include "afrl/cmasi/Circle.h"
 
 #ifdef AFRL_INTERNAL_ENABLED
 #include "afrl/famus/MustFlyTask.h"

--- a/src/cpp/Tasks/MustFlyTaskService.h
+++ b/src/cpp/Tasks/MustFlyTaskService.h
@@ -17,13 +17,14 @@
 #ifndef UXAS_SERVICE_TASK_MUST_FLY_TASK_SERVICE_H
 #define UXAS_SERVICE_TASK_MUST_FLY_TASK_SERVICE_H
 
+#include "TaskServiceBase.h"
 #include "UnitConversions.h"
 
-#include "afrl/cmasi/MustFlyTask.h"
 #include "uxas/messages/route/RouteRequest.h"
 
+#include "afrl/cmasi/MustFlyTask.h"
+
 #include <cstdint> // int64_t
-#include "TaskServiceBase.h"
 
 namespace uxas
 {

--- a/src/cpp/Tasks/OverwatchTaskService.cpp
+++ b/src/cpp/Tasks/OverwatchTaskService.cpp
@@ -16,21 +16,22 @@
 
 
 #include "OverwatchTaskService.h"
-
 #include "Position.h"
 #include "FlatEarth.h"
+
+#include "uxas/messages/task/TaskOption.h"
 
 #include "avtas/lmcp/LmcpXMLReader.h"
 #include "afrl/cmasi/VehicleActionCommand.h"
 #include "afrl/cmasi/GimbalStareAction.h"
 #include "afrl/cmasi/GimbalConfiguration.h"
 #include "afrl/cmasi/LoiterAction.h"
-#include "uxas/messages/task/TaskOption.h"
+
+#include "boost/filesystem.hpp"
 
 #include <sstream>      //std::stringstream
 #include <iostream>     // std::cout, cerr, etc
 #include <fstream>
-#include "boost/filesystem.hpp"
 
 namespace uxas
 {

--- a/src/cpp/Tasks/OverwatchTaskService.h
+++ b/src/cpp/Tasks/OverwatchTaskService.h
@@ -19,19 +19,20 @@
 
 #include "TaskServiceBase.h"
 #include "ServiceBase.h"
+#include "DynamicTaskServiceBase.h"
+
+#include "uxas/messages/task/TaskPlanOptions.h"
+#include "uxas/messages/task/TaskImplementationRequest.h"
+#include "uxas/messages/route/RoutePlan.h"
 
 #include "afrl/cmasi/AutomationRequest.h"
 #include "afrl/impact/WatchTask.h"
 #include "afrl/cmasi/EntityConfiguration.h"
 #include "afrl/cmasi/EntityState.h"
-#include "uxas/messages/task/TaskPlanOptions.h"
-#include "uxas/messages/task/TaskImplementationRequest.h"
-#include "uxas/messages/route/RoutePlan.h"
 
 #include <cstdint> // int64_t
 #include <unordered_set>
 #include <unordered_map>
-#include "DynamicTaskServiceBase.h"
 #include <deque>
 
 namespace uxas

--- a/src/cpp/Tasks/PatternSearchTaskService.cpp
+++ b/src/cpp/Tasks/PatternSearchTaskService.cpp
@@ -14,13 +14,20 @@
  * Created on February 16, 2016, 6:17 PM
  */
 
-
 #include "PatternSearchTaskService.h"
-
 #include "Position.h"
 #include "FileSystemUtilities.h"
 #include "Polygon.h"
 #include "Constants/Convert.h"
+
+#include "uxas/messages/task/SensorFootprintResponse.h"
+#include "uxas/messages/task/FootprintRequest.h"
+#include "uxas/messages/task/SensorFootprintRequests.h"
+#include "uxas/messages/task/TaskImplementationResponse.h"
+#include "uxas/messages/task/TaskOption.h"
+#include "uxas/messages/route/ROUTE.h"
+#include "uxas/messages/route/RouteConstraints.h"
+#include "uxas/messages/uxnative/VideoRecord.h"
 
 #include "afrl/cmasi/Circle.h"
 #include "afrl/cmasi/Polygon.h"
@@ -31,14 +38,6 @@
 #include "afrl/cmasi/GimbalAngleAction.h"
 #include "afrl/cmasi/GimbalConfiguration.h"
 #include "afrl/cmasi/CameraConfiguration.h"
-#include "uxas/messages/task/SensorFootprintResponse.h"
-#include "uxas/messages/task/FootprintRequest.h"
-#include "uxas/messages/task/SensorFootprintRequests.h"
-#include "uxas/messages/task/TaskImplementationResponse.h"
-#include "uxas/messages/task/TaskOption.h"
-#include "uxas/messages/route/ROUTE.h"
-#include "uxas/messages/route/RouteConstraints.h"
-#include "uxas/messages/uxnative/VideoRecord.h"
 
 #include "pugixml.hpp"
 

--- a/src/cpp/Tasks/RendezvousTask.cpp
+++ b/src/cpp/Tasks/RendezvousTask.cpp
@@ -18,12 +18,13 @@
 #include "RendezvousTask.h"
 #include "FlatEarth.h"
 #include "RouteExtension.h"
-#include "afrl/cmasi/AirVehicleConfiguration.h"
-#include "afrl/cmasi/AirVehicleState.h"
+
 #include "uxas/messages/task/RendezvousTask.h"
-#include "afrl/cmasi/VehicleActionCommand.h"
 #include "uxas/messages/uxnative/SpeedOverrideAction.h"
 
+#include "afrl/cmasi/AirVehicleConfiguration.h"
+#include "afrl/cmasi/AirVehicleState.h"
+#include "afrl/cmasi/VehicleActionCommand.h"
 #ifdef AFRL_INTERNAL_ENABLED
 #include "afrl/famus/PlanningState.h"
 #endif

--- a/src/cpp/Tasks/RendezvousTask.h
+++ b/src/cpp/Tasks/RendezvousTask.h
@@ -18,10 +18,12 @@
 #define UXAS_RENDEZVOUS_TASK_H
 
 #include "TaskServiceBase.h"
-#include "afrl/cmasi/AirVehicleConfiguration.h"
+
 #include "uxas/messages/task/TaskImplementationRequest.h"
 #include "uxas/messages/task/TaskAssignmentSummary.h"
 #include "uxas/messages/task/AssignmentCostMatrix.h"
+
+#include "afrl/cmasi/AirVehicleConfiguration.h"
 
 #include <unordered_map>
 

--- a/src/cpp/Tasks/TaskManagerService.cpp
+++ b/src/cpp/Tasks/TaskManagerService.cpp
@@ -14,32 +14,28 @@
  * Created on August 31, 2015, 6:17 PM
  */
 
-
 #include "TaskManagerService.h"
 #include "TaskServiceBase.h"
 
+#include "uxas/messages/task/UniqueAutomationRequest.h"
+#include "uxas/messages/uxnative/CreateNewService.h"
+#include "uxas/messages/uxnative/KillService.h"
 
+#include "avtas/lmcp/LmcpXMLReader.h"
 #include "afrl/cmasi/EntityConfiguration.h"
 #include "afrl/cmasi/EntityConfigurationDescendants.h"
 #include "afrl/cmasi/EntityState.h"
 #include "afrl/cmasi/EntityStateDescendants.h"
 #include "afrl/cmasi/AutomationRequest.h"
 #include "afrl/cmasi/AutomationResponse.h"
-#include "uxas/messages/task/UniqueAutomationRequest.h"
 #include "afrl/cmasi/Task.h"
 #include "afrl/cmasi/TaskDescendants.h"
 #include "afrl/cmasi/RemoveTasks.h"
 #include "afrl/cmasi/FollowPathCommand.h"
-#include "uxas/messages/uxnative/CreateNewService.h"
-#include "uxas/messages/uxnative/KillService.h"
-#include "avtas/lmcp/LmcpXMLReader.h"
 #include "afrl/cmasi/FollowPathCommand.h"      
-
 #include "afrl/impact/PointOfInterest.h"
 #include "afrl/impact/LineOfInterest.h"
 #include "afrl/impact/AreaOfInterest.h"
-
-
 
 #include "pugixml.hpp"
 
@@ -48,7 +44,6 @@
 #include <fstream>     // std::ifstream
 #include <cstdint>
 #include <memory>      //int64_t
-
 
 #define STRING_XML_TYPE "Type"
 #define STRING_XML_TASKOPTIONS "TaskOptions"

--- a/src/cpp/Tasks/TaskManagerService.h
+++ b/src/cpp/Tasks/TaskManagerService.h
@@ -21,13 +21,14 @@
 
 #include "afrl/cmasi/EntityConfiguration.h"
 #include "afrl/cmasi/EntityState.h"
-#include "afrl/impact/AreaOfInterest.h"
-#include "afrl/impact/LineOfInterest.h"
-#include "afrl/impact/PointOfInterest.h"
 #include "afrl/cmasi/MissionCommand.h"
 #include "afrl/cmasi/KeepInZone.h"
 #include "afrl/cmasi/KeepOutZone.h"
 #include "afrl/cmasi/OperatingRegion.h"
+#include "afrl/impact/AreaOfInterest.h"
+#include "afrl/impact/LineOfInterest.h"
+#include "afrl/impact/PointOfInterest.h"
+
 #include <set>
 #include <cstdint> // int64_t
 

--- a/src/cpp/Tasks/TaskServiceBase.cpp
+++ b/src/cpp/Tasks/TaskServiceBase.cpp
@@ -15,20 +15,19 @@
  */
 
 #include "TaskServiceBase.h"
-
 #include "UnitConversions.h"
 #include "FileSystemUtilities.h"
-
 #include "Dpss.h"    //from OHARA
 
+#include "uxas/messages/task/TaskComplete.h"
+#include "uxas/messages/task/TaskInitialized.h"
+#include "uxas/messages/task/TaskActive.h"
+
+#include "avtas/lmcp/LmcpXMLReader.h"
 #include "afrl/cmasi/EntityConfiguration.h"
 #include "afrl/cmasi/EntityConfigurationDescendants.h"
 #include "afrl/cmasi/EntityState.h"
 #include "afrl/cmasi/EntityStateDescendants.h"
-#include "avtas/lmcp/LmcpXMLReader.h"
-#include "uxas/messages/task/TaskComplete.h"
-#include "uxas/messages/task/TaskInitialized.h"
-#include "uxas/messages/task/TaskActive.h"
 
 #include <algorithm>      //std::find_if
 #include <sstream>      //std::stringstream

--- a/src/cpp/Tasks/TaskServiceBase.h
+++ b/src/cpp/Tasks/TaskServiceBase.h
@@ -20,15 +20,6 @@
 #include "ServiceBase.h"
 #include "Constants/Convert.h"
 
-#include "avtas/lmcp/Object.h"
-#include "afrl/cmasi/AltitudeType.h"
-#include "afrl/cmasi/Task.h"
-#include "afrl/cmasi/EntityConfiguration.h"
-#include "afrl/cmasi/EntityState.h"
-#include "afrl/cmasi/MissionCommand.h"
-#include "afrl/impact/AreaOfInterest.h"
-#include "afrl/impact/LineOfInterest.h"
-#include "afrl/impact/PointOfInterest.h"
 #include "uxas/messages/task/UniqueAutomationRequest.h"
 #include "uxas/messages/task/UniqueAutomationResponse.h"
 #include "uxas/messages/task/TaskImplementationResponse.h"
@@ -38,10 +29,20 @@
 #include "uxas/messages/route/RoutePlan.h"
 #include "uxas/messages/route/RoutePlanRequest.h"
 #include "uxas/messages/route/RoutePlanResponse.h"
+
+#include "avtas/lmcp/Object.h"
+#include "afrl/cmasi/AltitudeType.h"
+#include "afrl/cmasi/Task.h"
+#include "afrl/cmasi/EntityConfiguration.h"
+#include "afrl/cmasi/EntityState.h"
+#include "afrl/cmasi/MissionCommand.h"
 #include "afrl/cmasi/KeepInZone.h"
 #include "afrl/cmasi/KeepOutZone.h"
 #include "afrl/cmasi/OperatingRegion.h"
-#include <afrl/cmasi/SearchTask.h>
+#include "afrl/cmasi/SearchTask.h"
+#include "afrl/impact/AreaOfInterest.h"
+#include "afrl/impact/LineOfInterest.h"
+#include "afrl/impact/PointOfInterest.h"
 
 #include "pugixml.hpp"
 

--- a/src/cpp/Tasks/TaskTrackerService.h
+++ b/src/cpp/Tasks/TaskTrackerService.h
@@ -18,12 +18,13 @@
 #define UXAS_SERVICE_TASK_TASK_TRACKER_SERVICE_H
 
 #include "ServiceBase.h"
+#include "visilibity.h"
+
+#include "uxas/messages/route/ROUTE.h"
+
 #include "afrl/cmasi/CMASI.h"
 #include "afrl/impact/IMPACT.h"
 #include "afrl/vehicles/VEHICLES.h"
-#include "uxas/messages/route/ROUTE.h"
-
-#include "visilibity.h"
 
 #include <memory>
 #include <tuple>

--- a/src/cpp/Utilities/CallbackTimer.h
+++ b/src/cpp/Utilities/CallbackTimer.h
@@ -17,14 +17,12 @@
 #ifndef CALLBACKTIMER_H
 #define CALLBACKTIMER_H
 
-#include <thread>
-#include <mutex>
-
-#include <functional>
-
 #include "TypeDefs/UxAS_TypeDefs_Thread.h"
 //#include "TypeDefs/UxAS_TypeDefs_ZeroMQ.h"
 
+#include <thread>
+#include <mutex>
+#include <functional>
 
 namespace uxas
 {

--- a/src/cpp/Utilities/FileSystemUtilities.cpp
+++ b/src/cpp/Utilities/FileSystemUtilities.cpp
@@ -16,12 +16,9 @@
 
 
 
-#include "TimeUtilities.h"
-
 #include "FileSystemUtilities.h"
-
+#include "TimeUtilities.h"
 #include "UxAS_Log.h"
-
 #include "Constants/Constants_FileSystem.h"
 
 //BOOST FILESYSTEM

--- a/src/cpp/Utilities/FlatEarth.h
+++ b/src/cpp/Utilities/FlatEarth.h
@@ -34,6 +34,7 @@
 
 //#pragma warning(disable: 4786)
 
+#include "Constants/Convert.h"
 
 #include <cmath>
 #include <cassert>
@@ -45,7 +46,6 @@
 #include <crtdbg.h>        //assert
 #endif//#ifndef WIN32
 
-#include "Constants/Convert.h"
 
 
 namespace uxas

--- a/src/cpp/Utilities/RouteExtension.h
+++ b/src/cpp/Utilities/RouteExtension.h
@@ -1,10 +1,12 @@
 #ifndef RouteExtension_H
 #define RouteExtension_H
 
-#include <vector>
+#include "FlatEarth.h"
+
 #include "afrl/cmasi/Waypoint.h"
 #include "afrl/cmasi/MissionCommand.h"
-#include "FlatEarth.h"
+
+#include <vector>
 
 namespace uxas
 {

--- a/src/cpp/Utilities/TimeUtilities.h
+++ b/src/cpp/Utilities/TimeUtilities.h
@@ -17,14 +17,13 @@
 #ifndef TIMEUTILITIES_H
 #define TIMEUTILITIES_H
 
-#include <cstdint> // uint32_t
-
-#include <chrono>       // time functions
-
-//#include <mutex>
-
 #include "boost/date_time/gregorian/gregorian.hpp"
 #include "boost/date_time/posix_time/posix_time.hpp"
+
+#include <cstdint> // uint32_t
+#include <chrono>       // time functions
+//#include <mutex>
+
 namespace n_POSIX_TIME = boost::posix_time;
 
 namespace uxas

--- a/src/cpp/Utilities/UnitConversions.h
+++ b/src/cpp/Utilities/UnitConversions.h
@@ -47,6 +47,7 @@
 
 //#pragma warning(disable: 4786)
 
+#include "Constants/Convert.h"
 
 #include <cmath>
 #include <cassert>
@@ -57,9 +58,6 @@
 #ifdef _WIN32
 #include <crtdbg.h>        //assert
 #endif//#ifndef WIN32
-
-#include "Constants/Convert.h"
-
 
 namespace uxas
 {

--- a/src/cpp/UxAS_Main.cpp
+++ b/src/cpp/UxAS_Main.cpp
@@ -7,8 +7,6 @@
 // Title 17, U.S. Code.  All Other Rights Reserved.
 // ===============================================================================
 
-#include "afrl/cmasi/AirVehicleState.h"
-#include "afrl/impact/AreaOfInterest.h"
 
 #include "LmcpObjectNetworkBridgeManager.h"
 #include "LmcpObjectNetworkServer.h"
@@ -21,15 +19,15 @@
 #include "UxAS_Log.h"
 #include "UxAS_LogManagerDefaultInitializer.h"
 #include "UxAS_StringUtil.h"
+#include "stdUniquePtr.h"
+#include "FileSystemUtilities.h"
 
+#include "afrl/cmasi/AirVehicleState.h"
+#include "afrl/impact/AreaOfInterest.h"
 #ifdef AFRL_INTERNAL_ENABLED
 #include "afrl/famus/PointSearchTask.h"
 //#include "UxAS_SerialPortEmulator.h"
 #endif
-
-#include "stdUniquePtr.h"
-
-#include "FileSystemUtilities.h"
 
 #include <iostream>
 #include <memory>

--- a/src/cpp/VisilibityLib/visilibity.cpp
+++ b/src/cpp/VisilibityLib/visilibity.cpp
@@ -34,6 +34,10 @@ License along with VisiLibity.  If not, see <http://www.gnu.org/licenses/>.
 
 
 #include "visilibity.h"  //VisiLibity header
+
+#include "boost/geometry/algorithms/is_valid.hpp"
+#include "boost/geometry/algorithms/validity_failure_type.hpp"
+
 #include <cmath>         //math functions in std namespace
 #include <vector>
 #include <queue>         //queue and priority_queue
@@ -50,8 +54,6 @@ License along with VisiLibity.  If not, see <http://www.gnu.org/licenses/>.
 #include <cassert>       //assertions
 #include <iso646.h>      //aliases for boolean operators
 
-#include "boost/geometry/algorithms/is_valid.hpp"
-#include "boost/geometry/algorithms/validity_failure_type.hpp"
 
 ///Hide helping functions in unnamed namespace (local to .C file).
 namespace

--- a/src/cpp/VisilibityLib/visilibity.h
+++ b/src/cpp/VisilibityLib/visilibity.h
@@ -53,6 +53,10 @@ License along with VisiLibity.  If not, see <http://www.gnu.org/licenses/>.
 #ifndef VISILIBITY_H
 #define VISILIBITY_H
 
+#include "boost/geometry.hpp"
+#include "boost/geometry/geometries/point_xy.hpp"
+#include "boost/geometry/geometries/polygon.hpp"
+
 #ifndef NAN
 #include <limits>
 #define NAN std::numeric_limits<double>::quiet_NaN()
@@ -83,10 +87,6 @@ License along with VisiLibity.  If not, see <http://www.gnu.org/licenses/>.
 #include <cstring>    //C-string manipulation
 #include <string>     //string class
 #include <cassert>    //assertions
-
-#include "boost/geometry.hpp"
-#include "boost/geometry/geometries/point_xy.hpp"
-#include "boost/geometry/geometries/polygon.hpp"
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
1. "using namespace" should not be placed in header files as this can be dangerous.  Only include at the source file level.
2. Re-order includes to avoid implicit dependence on other headers, use following order: 
    1. Header for this source file 
    2. OpenUxAS header files 
    3. Government headers (e.g. LMCP) 
    4. 3rd party headers 
    5. C++ STL and system headers