### PR TITLE
update for "relaxed initialization" changes in Lmcpgen ByteBuffers code

### DIFF
--- a/src/ada/src/comms/uxas-comms-lmcp_net_client.adb
+++ b/src/ada/src/comms/uxas-comms-lmcp_net_client.adb
@@ -143,10 +143,10 @@ package body UxAS.Comms.LMCP_Net_Client is
       --  PDR: note we don't just call Put_String because that would first put
       --  the length, which the C++ code doesn't do
       for C of Payload loop
-         Buffer.Put_Byte (Character'Pos (C));
+         Put_Byte (Buffer, Character'Pos (C));
       end loop;
       --  lmcpByteBuffer.rewind();
-      Buffer.Rewind;
+      Rewind (Buffer);
 
       --  lmcpObject.reset(AVTAS::lmcp::Factory::getObject(lmcpByteBuffer));
       AVTAS.LMCP.Factory.getObject (Buffer, Result);

--- a/src/ada/src/comms/uxas-comms-lmcp_object_message_receiver_pipes.adb
+++ b/src/ada/src/comms/uxas-comms-lmcp_object_message_receiver_pipes.adb
@@ -211,8 +211,8 @@ package body UxAS.Comms.LMCP_Object_Message_Receiver_Pipes is
       pragma Unreferenced (This);
       Buffer : ByteBuffer (Payload'Length);
    begin
-      Buffer.Put_Raw_Bytes (Payload);
-      Buffer.Rewind;
+      Put_Raw_Bytes (Buffer, Payload);
+      Rewind (Buffer);
 
       AVTAS.LMCP.Factory.getObject (Buffer, Message);
    end Deserialize_Message;

--- a/src/ada/src/comms/uxas-comms-lmcp_object_message_sender_pipes.adb
+++ b/src/ada/src/comms/uxas-comms-lmcp_object_message_sender_pipes.adb
@@ -154,7 +154,7 @@ package body UxAS.Comms.LMCP_Object_Message_Sender_Pipes is
       --  AVTAS::lmcp::ByteBuffer* lmcpByteBuffer = AVTAS::lmcp::Factory::packMessage(lmcpObject.get(), true);
       Buffer  : constant ByteBuffer := AVTAS.LMCP.Factory.packMessage (Message, enableChecksum => True);
       --  std::string serializedPayload = std::string(reinterpret_cast<char*>(lmcpByteBuffer->array()), lmcpByteBuffer->capacity());
-      Payload : constant String := Buffer.Raw_Bytes;
+      Payload : constant String := Buffer.Raw_Bytes_As_String;
    begin
       --  m_transportSender->sendMessage
       --   (castAddress,
@@ -206,7 +206,7 @@ package body UxAS.Comms.LMCP_Object_Message_Sender_Pipes is
       --  AVTAS::lmcp::ByteBuffer* lmcpByteBuffer = AVTAS::lmcp::Factory::packMessage(lmcpObject.get(), true);
       Buffer  : constant ByteBuffer := AVTAS.LMCP.Factory.packMessage (Message, enableChecksum => True);
       --  std::string serializedPayload = std::string(reinterpret_cast<char*>(lmcpByteBuffer->array()), lmcpByteBuffer->capacity());
-      Payload : constant String := Buffer.Raw_Bytes;
+      Payload : constant String := Buffer.Raw_Bytes_As_String;
    begin
       --  Note: this body is identical to the body of Send_LimitedCast_Message, per the C++ implementation
       --  TODO: see why

--- a/src/ada/src/comms/uxas-comms-lmcp_object_message_sender_pipes.adb
+++ b/src/ada/src/comms/uxas-comms-lmcp_object_message_sender_pipes.adb
@@ -154,7 +154,7 @@ package body UxAS.Comms.LMCP_Object_Message_Sender_Pipes is
       --  AVTAS::lmcp::ByteBuffer* lmcpByteBuffer = AVTAS::lmcp::Factory::packMessage(lmcpObject.get(), true);
       Buffer  : constant ByteBuffer := AVTAS.LMCP.Factory.packMessage (Message, enableChecksum => True);
       --  std::string serializedPayload = std::string(reinterpret_cast<char*>(lmcpByteBuffer->array()), lmcpByteBuffer->capacity());
-      Payload : constant String := Buffer.Raw_Bytes_As_String;
+      Payload : constant String := Raw_Bytes_As_String (Buffer);
    begin
       --  m_transportSender->sendMessage
       --   (castAddress,
@@ -206,7 +206,7 @@ package body UxAS.Comms.LMCP_Object_Message_Sender_Pipes is
       --  AVTAS::lmcp::ByteBuffer* lmcpByteBuffer = AVTAS::lmcp::Factory::packMessage(lmcpObject.get(), true);
       Buffer  : constant ByteBuffer := AVTAS.LMCP.Factory.packMessage (Message, enableChecksum => True);
       --  std::string serializedPayload = std::string(reinterpret_cast<char*>(lmcpByteBuffer->array()), lmcpByteBuffer->capacity());
-      Payload : constant String := Buffer.Raw_Bytes_As_String;
+      Payload : constant String := Raw_Bytes_As_String (Buffer);
    begin
       --  Note: this body is identical to the body of Send_LimitedCast_Message, per the C++ implementation
       --  TODO: see why


### PR DESCRIPTION
Don't use distinguished receiver syntax in calls to ByteBuffer routines.