### PR TITLE
Fix for #99: `run-example` broken without GNAT

### DIFF
--- a/anod
+++ b/anod
@@ -30,9 +30,11 @@ function _anod {
     # Look ahead to see if we're building uxas-ada
     if is_first_positional_arg "$*" "build" && contains "$*" "uxas-ada"; then
         ensure_gnat
+
+    # Likewise, if we're running printenv for uxas-ada's build environment, we
+    # should try to put the alire-installed gnat on the path
     elif is_first_positional_arg "$*" "printenv" && contains "$*" "uxas-ada" && contains "$*" "--build-env"; then
         print_gnat_fsf_paths
-        ensure_gnat
     fi
 
     # Look ahead to process specific commands.

--- a/infrastructure/paths.sh
+++ b/infrastructure/paths.sh
@@ -103,7 +103,7 @@ ALR_PRINTENV_CMD="( cd \"${ALR_DIR}/gnatprove\" && \"${ALR_DIR}/bin/alr\" -c \"$
 function print_gnat_fsf_paths {
     which gnat >/dev/null 2>&1
 
-    if [ $? -ne 0 ]; then
+    if [[ $? -ne 0 && -d "${ALR_DIR}/gnatprove" ]]; then
         debug_and_run "${ALR_PRINTENV_CMD}"
     fi
 }


### PR DESCRIPTION
The script support to add GNAT FSF after Alire installation meant `./anod printenv uxas-ada --build-env` couldn't be speculatively run by the `run-example` script if GNAT was not on the path or installed by Alire. The fix to #99 simply avoids executing Alire's own printenv if it's not been installed.