### PR TITLE
Changes to support Ubuntu 24.04

### DIFF
--- a/.github/workflows/amase.yaml
+++ b/.github/workflows/amase.yaml
@@ -24,8 +24,8 @@ jobs:
             fail-fast: false
             matrix:
                 env: [
-                    {os: ubuntu-20.04, python: '3.8'},
-                    {os: ubuntu-22.04, python: '3.10'}
+                    {os: ubuntu-22.04, python: '3.10'},
+                    {os: ubuntu-24.04, python: '3.12'}
                 ]
                 component: [amase]
                 qualifier: [scenario=release]

--- a/.github/workflows/infrastructure-install.yaml
+++ b/.github/workflows/infrastructure-install.yaml
@@ -16,8 +16,8 @@ jobs:
             fail-fast: false
             matrix:
                 env: [
-                    {os: ubuntu-20.04, python: '3.8'},
-                    {os: ubuntu-22.04, python: '3.10'}
+                    {os: ubuntu-22.04, python: '3.10'},
+                    {os: ubuntu-24.04, python: '3.12'}
                 ]
         runs-on: ${{ matrix.env.os }}
         steps:

--- a/.github/workflows/run-example.yaml
+++ b/.github/workflows/run-example.yaml
@@ -30,8 +30,8 @@ jobs:
             fail-fast: false
             matrix:
                 env: [
-                    {os: ubuntu-20.04, python: '3.8'},
-                    {os: ubuntu-22.04, python: '3.10'}
+                    {os: ubuntu-22.04, python: '3.10'},
+                    {os: ubuntu-24.04, python: '3.12'}
                 ]
         runs-on: ${{ matrix.env.os }}
         steps:

--- a/.github/workflows/run-lmcpgen.yaml
+++ b/.github/workflows/run-lmcpgen.yaml
@@ -26,8 +26,8 @@ jobs:
             fail-fast: false
             matrix:
                 env: [
-                    {os: ubuntu-20.04, python: '3.8'},
-                    {os: ubuntu-22.04, python: '3.10'}
+                    {os: ubuntu-22.04, python: '3.10'},
+                    {os: ubuntu-24.04, python: '3.12'}
                 ]
         runs-on: ${{ matrix.env.os }}
         steps:

--- a/.github/workflows/uxas-ada.yaml
+++ b/.github/workflows/uxas-ada.yaml
@@ -28,8 +28,8 @@ jobs:
             fail-fast: false
             matrix:
                 env: [
-                    {os: ubuntu-20.04, python: '3.8'},
-                    {os: ubuntu-22.04, python: '3.10'}
+                    {os: ubuntu-22.04, python: '3.10'},
+                    {os: ubuntu-24.04, python: '3.12'}
                 ]
                 component: [uxas-ada]
                 qualifier: [scenario=release]

--- a/.github/workflows/uxas-cpp.yaml
+++ b/.github/workflows/uxas-cpp.yaml
@@ -28,8 +28,8 @@ jobs:
             fail-fast: false
             matrix:
                 env: [
-                    {os: ubuntu-20.04, python: '3.8'},
-                    {os: ubuntu-22.04, python: '3.10'}
+                    {os: ubuntu-22.04, python: '3.10'},
+                    {os: ubuntu-24.04, python: '3.12'}
                 ]
                 component: [uxas]
                 qualifier: [scenario=release, scenario=gcov]

--- a/.github/workflows/uxas-module.yaml
+++ b/.github/workflows/uxas-module.yaml
@@ -16,8 +16,8 @@ jobs:
             fail-fast: false
             matrix:
                 env: [
-                    {os: ubuntu-20.04, python: '3.8'},
-                    {os: ubuntu-22.04, python: '3.10'}
+                    {os: ubuntu-22.04, python: '3.10'},
+                    {os: ubuntu-24.04, python: '3.12'}
                 ]
         runs-on: ${{ matrix.env.os }}
         steps:

--- a/infrastructure/install-libexec/install-anod-venv.py
+++ b/infrastructure/install-libexec/install-anod-venv.py
@@ -53,7 +53,7 @@ APT_INSTALL = Command(
         "uuid-dev",
         "libyaml-dev",
         "python3-dev",
-        "python3-distutils",
+        "python3-setuptools",
         "python3-venv",
         "python3-pip",
         # For a system-wide boost, we need these packages. Commented out until

--- a/src/cpp/Utilities/localcoords/setup.py
+++ b/src/cpp/Utilities/localcoords/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 module1 = Extension('LocalCoords',sources=['LocalCoordsModule.cpp',
                                            '../UnitConversions.cpp'],


### PR DESCRIPTION
* Remove python3-binutils and replace with python3-setuptools. 
* Update the localcoords setup script for the change.
* Update the CI to drop Ubuntu 20.04 and add Ubuntu 24.04 with python 3.12

Note: the localcoords script is trying to do a systemwide install of a C++ module for use in python. This is probably not what's best for OpenUxAS users.