### PR TITLE
Fix spurious report from safety

### DIFF
--- a/infrastructure/uxas/tox.ini
+++ b/infrastructure/uxas/tox.ini
@@ -29,7 +29,10 @@ deps =
 commands =
     # skipped tests relate to the use of subprocess in devel_setup
     bandit -r src -s B404,B603,B607
-    safety check --full-report
+
+    # skipped check is a report on a pip vulnerability that doesn't impact
+    # OpenUxAS usage; see CVE-2018-20225
+    safety check --full-report --ignore 67599
 
 [pytest]
 addopts = --failed-first


### PR DESCRIPTION
As noted in issue #118, `safety` is reporting on CVE-2018-20225 for pip. This behavior doesn't impact us, as we don't use a custom index; we always get packages from pypi.