### PR TITLE
Fixed safety error on daidalus_integration.

### DIFF
--- a/infrastructure/uxas/tox.ini
+++ b/infrastructure/uxas/tox.ini
@@ -29,7 +29,7 @@ deps =
 commands =
     # skipped tests relate to the use of subprocess in devel_setup
     bandit -r src -s B404,B603,B607
-    safety check --full-report
+    safety check --full-report --ignore 67599
 
 [pytest]
 addopts = --failed-first


### PR DESCRIPTION
Fixed safety error with pip by editing infrastructure/uxas/tox.ini and adding " --ignore 67599" to line 32.