### PR TITLE
Update tox.ini to remove safety check.

### DIFF
--- a/infrastructure/uxas/tox.ini
+++ b/infrastructure/uxas/tox.ini
@@ -32,7 +32,8 @@ commands =
 
     # skipped check is a report on a pip vulnerability that doesn't impact
     # OpenUxAS usage; see CVE-2018-20225
-    safety check --full-report --ignore 67599
+    # Safety check removed for spurious fails.  No longer used from Adacore's side.
+    #   safety check --full-report --ignore 67599
 
 [pytest]
 addopts = --failed-first


### PR DESCRIPTION
Removed unnecessary safety check to prevent spurious failures.