### PR TITLE
Fix minimum-time Dubins path lengthening units

### DIFF
--- a/src/cpp/Plans/Trajectory.cpp
+++ b/src/cpp/Plans/Trajectory.cpp
@@ -236,12 +236,11 @@ double CTrajectory::dMinimumDistanceDubins(CTrajectoryParameters& cTrajectoryPar
         ////////////////////////////////////////////////////////////////////////////////////////
         if(cTrajectoryParameters.bGetLengthenPath())
         {
-            //TODO:: this needs to be in terms of time
-            double dMinTimeToLengthen_s = cTrajectoryParameters.dGetMinimumTime_s() - 
-                                                    (dDistanceTotalMinimum_m*cTrajectoryParameters.dGetSpeed_mps());
-            if(dMinTimeToLengthen_s > 0.0)
+            double dMinimumPathLength_m = cTrajectoryParameters.dGetMinimumTime_s() *
+                                                    cTrajectoryParameters.dGetSpeed_mps();
+            if(dDistanceTotalMinimum_m < dMinimumPathLength_m)
             {
-                dDistanceTotalMinimum_m = dLengthenPath(cTrajectoryParameters,dMinTimeToLengthen_s,assignMinimum);
+                dDistanceTotalMinimum_m = dLengthenPath(cTrajectoryParameters,dMinimumPathLength_m,assignMinimum);
             }
         }
         cTrajectoryParameters.vGetWaypoints() = assignMinimum.vwayGetWaypoints();
@@ -382,7 +381,7 @@ CTrajectory::CalculateTaskHeading(CTrajectoryParameters& cTrajectoryParameters)
 
 
 double CTrajectory::dLengthenPath(CTrajectoryParameters& cTrajectoryParameters,
-                                    double dMinTimeToLengthen_s,CAssignment& assignMinimum)
+                                    double dMinimumPathLength_m,CAssignment& assignMinimum)
 {
     // ASSUMES::
     // "assignMinimum" contains the following waypoints:
@@ -508,7 +507,7 @@ double CTrajectory::dLengthenPath(CTrajectoryParameters& cTrajectoryParameters,
     }
 
 
-    double dDistanceLoiter = dMinTimeToLengthen_s - (dDistanceInitialLeg_m + dDistanceFinalLeg_m);
+    double dDistanceLoiter = dMinimumPathLength_m - (dDistanceInitialLeg_m + dDistanceFinalLeg_m);
     dDistanceLoiter = (dDistanceLoiter>0.0)?(dDistanceLoiter):(0.0);
 
     double dAngleLoiter(0.0);

--- a/src/cpp/Plans/Trajectory.h
+++ b/src/cpp/Plans/Trajectory.h
@@ -96,7 +96,7 @@ protected: //member functions
 
     void CalculateTaskHeading(CTrajectoryParameters& cTrajectoryParameters);
     double dLengthenPath(CTrajectoryParameters& cTrajectoryParameters,
-                            double dMinTimeToLengthen_s,CAssignment& assignMinimum);
+                            double dMinimumPathLength_m,CAssignment& assignMinimum);
 
     std::vector<std::vector<double>> FindLimitTurn(double* Waypoint1,double* Waypoint2,double alpha,double minStep);
     std::vector<std::vector<double>> FindPathBetweenTurns(std::vector<std::vector<double>> Turn1,std::vector<std::vector<double>> Turn2,double LengthFirstSegment,double RegularStep, 


### PR DESCRIPTION
## Summary

Corrects a unit mismatch in `CTrajectory::dMinimumDistanceDubins` when enforcing a minimum task-completion time.

The current Dubins branch computes:

```cpp
minimumTime_s - (distance_m * speed_mps)
```

and passes that result to `dLengthenPath`. The operands in that expression have incompatible units, and `dLengthenPath` actually treats its second argument as a **distance**: it subtracts metre-valued path legs from it, converts the remaining loiter distance to an angle using a radius, and returns a distance.

The Euclidean trajectory branch already uses the dimensionally consistent relationship:

```text
minimum path length [m] = minimum time [s] * speed [m/s]
```

This change makes the Dubins branch use the same relationship.

## Example

For a 100 m Dubins path at 10 m/s with a requested minimum time of 20 s, the required path length is 200 m.

The existing expression evaluates as `20 - (100 * 10) = -980`, so path lengthening is not triggered. The corrected logic compares `100 m < 200 m` and invokes `dLengthenPath` with the 200 m target.

## Changes

- compute `dMinimumPathLength_m` as `dGetMinimumTime_s() * dGetSpeed_mps()`;
- compare the current Dubins path length against that target;
- pass the target path length, in metres, to `dLengthenPath`;
- rename the helper parameter from `dMinTimeToLengthen_s` to `dMinimumPathLength_m` so its actual units are explicit.

## Validation

- `git diff --check` passes;
- verified the stale `_s` distance parameter is removed;
- verified the existing Euclidean minimum-time conversion is unchanged;
- branch is based directly on current upstream `develop` (`5d413214bd1ccdfcb4185cd9bd1e37b1ed9bf1ad`);
- branch contains one commit and modifies only `src/cpp/Plans/Trajectory.cpp` and `src/cpp/Plans/Trajectory.h`;
- no matching open issue or pull request was found for this defect.

No flight or hardware validation is claimed; repository CI provides the executable build/test validation for this change.