### PR TITLE
Fix duplicate base name in unique filenames on non-Windows

### DIFF
--- a/src/cpp/Utilities/FileSystemUtilities.cpp
+++ b/src/cpp/Utilities/FileSystemUtilities.cpp
@@ -63,7 +63,7 @@ namespace utilities
                 sstrNewFileName << ".xml";
 #else
                 sstrNewFileName 
-                        << "_" << strFileNameBase << "_" << std::setprecision(5) << uxas::common::utilities::c_TimeUtilities::strGetTimeNow();
+                        << "_" << std::setprecision(5) << uxas::common::utilities::c_TimeUtilities::strGetTimeNow();
 #endif
             }
             strPathFileName = strPath + "/" + sstrNewFileName.str();


### PR DESCRIPTION
## Summary

Fixes `c_FileSystemUtilities::bFindUniqueFileName` generating the file-name base twice on non-Windows platforms when `isAddExtension` is enabled.

The function already builds the name as:

```text
<number>_<base>
```

but the non-Windows suffix then appends:

```text
_<base>_<timestamp>
```

so a base such as `messages` becomes `0001_messages_messages_<timestamp>`.

The other file-saving paths in the same utility establish the intended non-Windows convention as:

```text
<number>_<base>_<timestamp>
```

and the Windows branch similarly includes the base only once before adding `.xml`.

This change removes only the second `strFileNameBase` insertion from the non-Windows suffix.

## Impact

- non-Windows unique filenames no longer repeat their base name;
- numeric prefixes are unchanged;
- timestamps are unchanged;
- Windows filename behavior is unchanged;
- `isAddExtension == false` behavior is unchanged;
- no public API changes.

## Validation

- verified the duplicated expression occurs exactly once in `bFindUniqueFileName`;
- verified sibling non-Windows save paths use the single-base `<number>_<base>_<timestamp>` convention;
- `git diff --check` passes;
- branch is based directly on current upstream `develop` (`5d413214bd1ccdfcb4185cd9bd1e37b1ed9bf1ad`);
- branch contains one commit and changes one line in `src/cpp/Utilities/FileSystemUtilities.cpp`;
- no matching open issue or pull request was found for this defect;
- repository C++ and run-example CI are running on the clean branch head.
